### PR TITLE
exfaprogs: add missing warning options in lib/Makefile.am

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,4 +1,6 @@
-AM_CFLAGS = -include $(top_srcdir)/config.h -I$(top_srcdir)/include -fno-common
+AM_CFLAGS = -Wall -Werror -Wunused-parameter \
+	    -Wno-address-of-packed-member \
+	    -include $(top_srcdir)/config.h -I$(top_srcdir)/include -fno-common
 LIBS = -lc
 lib_LTLIBRARIES = libexfat.la
 


### PR DESCRIPTION
Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>