### PR TITLE
exfatprogs: release 1.0.2 version

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.0.1"
+#define EXFAT_PROGS_VERSION "1.0.2"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
The major changes in this release:
* Rename project name to exfatprogs.
* label.exfat: Add support for label.exfat to set/get exfat volume label.
* Replace iconv library by standard C functions mbstowcs() and wcrtomb().
* Fix the build warnings/errors and add warning options.
* Fix several bugs(memory leak, wrong endian conversion, zero out beyond end of file) and cleanup codes
* Fix issues on big endian system and on 32bit system.
* Add support for Android build system.

Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>