### PR TITLE
Do not install library files

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.0.1"
+#define EXFAT_PROGS_VERSION "1.0.2"
 
 #endif /* !_VERSION_H */

--- a/label/label.c
+++ b/label/label.c
@@ -61,7 +61,6 @@ static off_t exfat_get_root_entry_offset(struct exfat_blk_dev *bd)
 		* cluster_size;
 	free(bs);
 
-	exfat_debug("root cluster offset : %ld\n", root_clu_off);
 	return root_clu_off;
 }
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -2,6 +2,6 @@ AM_CFLAGS = -Wall -Werror -Wunused-parameter \
 	    -Wno-address-of-packed-member \
 	    -include $(top_srcdir)/config.h -I$(top_srcdir)/include -fno-common
 LIBS = -lc
-lib_LTLIBRARIES = libexfat.la
+noinst_LTLIBRARIES = libexfat.la
 
 libexfat_la_SOURCES = libexfat.c


### PR DESCRIPTION
I don't think we require to provide a devel package since there would not be any software which develops against libexfat. Disable installation of the library.

Note this builds programs mkfs.exfat, fsck.exfat including libexfat as opposed to a shared library. Check with ldd <executable> for details.

Fixes Issue#61