### PR TITLE
exfatprogs: add missing #include <sys/types.h>

### DIFF
--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -6,6 +6,7 @@
 #ifndef _LIBEXFAT_H
 
 #include <stdbool.h>
+#include <sys/types.h>
 #include <wchar.h>
 
 #define KB			(1024)


### PR DESCRIPTION
Fixes:
../include/libexfat.h:72:1: error: unknown type name ‘ssize_t’
 ssize_t exfat_read(int fd, void *buf, size_t size, off_t offset);
 ^
../include/libexfat.h:72:52: error: unknown type name ‘off_t’
 ssize_t exfat_read(int fd, void *buf, size_t size, off_t offset);
                                                    ^
../include/libexfat.h:73:1: error: unknown type name ‘ssize_t’
 ssize_t exfat_write(int fd, void *buf, size_t size, off_t offset);
 ^
../include/libexfat.h:73:53: error: unknown type name ‘off_t’
 ssize_t exfat_write(int fd, void *buf, size_t size, off_t offset);
                                                     ^
../include/libexfat.h:75:1: error: unknown type name ‘ssize_t’
 ssize_t exfat_utf16_enc(const char *in_str, __u16 *out_str, size_t out_size);
 ^
../include/libexfat.h:76:1: error: unknown type name ‘ssize_t’
 ssize_t exfat_utf16_dec(const __u16 *in_str, size_t in_len,
 ^

Signed-off-by: James Hilliard <james.hilliard1@gmail.com>