### PR TITLE
exfatprogs: remove -Werror to avoid build break

### DIFF
--- a/fsck/Makefile.am
+++ b/fsck/Makefile.am
@@ -1,6 +1,4 @@
-AM_CFLAGS = -Wall -Werror -Wunused-parameter \
-	    -Wno-address-of-packed-member \
-	    -include $(top_srcdir)/config.h -I$(top_srcdir)/include -fno-common
+AM_CFLAGS = -Wall -include $(top_srcdir)/config.h -I$(top_srcdir)/include -fno-common
 fsck_exfat_LDADD = $(top_builddir)/lib/libexfat.la
 
 sbin_PROGRAMS = fsck.exfat

--- a/mkfs/Makefile.am
+++ b/mkfs/Makefile.am
@@ -1,6 +1,4 @@
-AM_CFLAGS = -Wall -Werror -Wunused-parameter \
-	    -Wno-address-of-packed-member \
-	    -include $(top_srcdir)/config.h -I$(top_srcdir)/include -fno-common
+AM_CFLAGS = -Wall -include $(top_srcdir)/config.h -I$(top_srcdir)/include -fno-common
 LIBS = -lm
 mkfs_exfat_LDADD = $(top_builddir)/lib/libexfat.la
 


### PR DESCRIPTION
There is some warning option which is reconized by only gcc version(gcc-9)
like -Wno-address-of-packed-member. To avoid the build break, remove it
and leave only -Wall.

Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>