### PR TITLE
mkfs/fsck: use PRIu64/PRIx64 to print 64-bit types (fixes issues #64)

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -722,7 +722,7 @@ static bool check_inode(struct exfat *exfat, struct exfat_inode *parent,
 	if (node->size > le32_to_cpu(exfat->bs->bsx.clu_count) *
 				EXFAT_CLUSTER_SIZE(exfat->bs)) {
 		resolve_path_parent(&path_resolve_ctx, parent, node);
-		exfat_err("size %llu is greater than cluster heap: %s\n",
+		exfat_err("size %" PRIu64 " is greater than cluster heap: %s\n",
 				node->size, path_resolve_ctx.local_path);
 		ret = false;
 	}
@@ -737,7 +737,7 @@ static bool check_inode(struct exfat *exfat, struct exfat_inode *parent,
 	if ((node->attr & ATTR_SUBDIR) &&
 			node->size % EXFAT_CLUSTER_SIZE(exfat->bs) != 0) {
 		resolve_path_parent(&path_resolve_ctx, parent, node);
-		exfat_err("directory size %llu is not divisible by %d: %s\n",
+		exfat_err("directory size %" PRIu64 " is not divisible by %d: %s\n",
 				node->size, EXFAT_CLUSTER_SIZE(exfat->bs),
 				path_resolve_ctx.local_path);
 		ret = false;
@@ -849,7 +849,7 @@ static int read_file_dentries(struct exfat_de_iter *iter,
 
 	if (le64_to_cpu(stream_de->stream_valid_size) > node->size) {
 		resolve_path_parent(&path_resolve_ctx, iter->parent, node);
-		exfat_err("valid size %" PRIu64 " greater than size %llu: %s\n",
+		exfat_err("valid size %" PRIu64 " greater than size %" PRIu64 ": %s\n",
 			le64_to_cpu(stream_de->stream_valid_size), node->size,
 			path_resolve_ctx.local_path);
 		goto err;
@@ -1176,7 +1176,7 @@ static bool exfat_root_dir_check(struct exfat *exfat)
 	root->size = clus_count * EXFAT_CLUSTER_SIZE(exfat->bs);
 
 	exfat->root = root;
-	exfat_debug("root directory: start cluster[0x%x] size[0x%llx]\n",
+	exfat_debug("root directory: start cluster[0x%x] size[0x%" PRIx64 "]\n",
 		root->first_clus, root->size);
 	return true;
 err:

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <string.h>
 #include <errno.h>
 #include <locale.h>
@@ -481,7 +482,7 @@ static bool exfat_boot_region_check(struct exfat *exfat)
 
 	if (le64_to_cpu(bs->bsx.vol_length) * EXFAT_SECTOR_SIZE(bs) >
 			exfat->blk_dev->size) {
-		exfat_err("too large sector count: %llu\n, expected: %llu\n",
+		exfat_err("too large sector count: %" PRIu64 "\n, expected: %llu\n",
 				le64_to_cpu(bs->bsx.vol_length),
 				exfat->blk_dev->num_sectors);
 		goto err;
@@ -848,7 +849,7 @@ static int read_file_dentries(struct exfat_de_iter *iter,
 
 	if (le64_to_cpu(stream_de->stream_valid_size) > node->size) {
 		resolve_path_parent(&path_resolve_ctx, iter->parent, node);
-		exfat_err("valid size %llu greater than size %llu: %s\n",
+		exfat_err("valid size %" PRIu64 " greater than size %llu: %s\n",
 			le64_to_cpu(stream_de->stream_valid_size), node->size,
 			path_resolve_ctx.local_path);
 		goto err;
@@ -927,7 +928,7 @@ static bool read_alloc_bitmap(struct exfat_de_iter *iter)
 	if (exfat_de_iter_get(iter, 0, &dentry))
 		return false;
 
-	exfat_debug("start cluster %#x, size %#llx\n",
+	exfat_debug("start cluster %#x, size %#" PRIx64 "\n",
 			le32_to_cpu(dentry->bitmap_start_clu),
 			le64_to_cpu(dentry->bitmap_size));
 
@@ -935,7 +936,7 @@ static bool read_alloc_bitmap(struct exfat_de_iter *iter)
 
 	if (le64_to_cpu(dentry->bitmap_size) <
 			DIV_ROUND_UP(exfat->bit_count, 8)) {
-		exfat_err("invalid size of allocation bitmap. 0x%llx\n",
+		exfat_err("invalid size of allocation bitmap. 0x%" PRIx64 "\n",
 				le64_to_cpu(dentry->bitmap_size));
 		return false;
 	}
@@ -989,7 +990,7 @@ static bool read_upcase_table(struct exfat_de_iter *iter)
 	size = (size_t)le64_to_cpu(dentry->upcase_size);
 	if (size > EXFAT_MAX_UPCASE_CHARS * sizeof(__le16) ||
 			size == 0 || size % sizeof(__le16)) {
-		exfat_err("invalid size of upcase table. 0x%llx\n",
+		exfat_err("invalid size of upcase table. 0x%" PRIx64 "\n",
 			le64_to_cpu(dentry->upcase_size));
 		return false;
 	}

--- a/fsck/fsck.h
+++ b/fsck/fsck.h
@@ -18,7 +18,7 @@ struct exfat_inode {
 	clus_t			last_lclus;
 	clus_t			last_pclus;
 	__u16			attr;
-	__u64			size;
+	uint64_t		size;
 	bool			is_contiguous;
 	off_t			dentry_file_offset;
 	__le16			name[0];	/* only for directory */

--- a/include/exfat_ondisk.h
+++ b/include/exfat_ondisk.h
@@ -26,9 +26,9 @@
 #define cpu_to_le64(x)	(x)
 #endif
 
-#define le64_to_cpu(x)  cpu_to_le64(x)
-#define le32_to_cpu(x)  cpu_to_le32(x)
-#define le16_to_cpu(x)  cpu_to_le16(x)
+#define le64_to_cpu(x)  ((uint64_t)cpu_to_le64(x))
+#define le32_to_cpu(x)  ((uint32_t)cpu_to_le32(x))
+#define le16_to_cpu(x)  ((uint16_t)cpu_to_le16(x))
 
 #define PBR_SIGNATURE		0xAA55
 

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -13,6 +13,7 @@
 #include <sys/ioctl.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <errno.h>
 #include <math.h>
 #include <locale.h>
@@ -57,7 +58,7 @@ static void exfat_setup_boot_sector(struct pbr *ppbr,
 	memset(ppbr->boot_code, 0, 390);
 	ppbr->signature = cpu_to_le16(PBR_SIGNATURE);
 
-	exfat_debug("Volume Length(sectors) : %llu\n",
+	exfat_debug("Volume Length(sectors) : %" PRIu64 "\n",
 		le64_to_cpu(pbsx->vol_length));
 	exfat_debug("FAT Offset(sector offset) : %u\n",
 		le32_to_cpu(pbsx->fat_offset));


### PR DESCRIPTION
Change cpu_to_le64()/cpu_to_le32()/cpu_to_le16() defines to
return determined types (instead of __le64/__le32/__le16) and
use PRIu64/PRIx64 to print 64-bit types.

Fixes:

  mkfs.c:60:14: error: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘long unsigned int’ [-Werror=format=]
    exfat_debug("Volume Length(sectors) : %llu\n",
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  fsck.c:484:13: error: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘long unsigned int’ [-Werror=format=]
     exfat_err("too large sector count: %llu\n, expected: %llu\n",
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  fsck.c:851:13: error: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘long unsigned int’ [-Werror=format=]
     exfat_err("valid size %llu greater than size %llu: %s\n",
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  fsck.c:930:14: error: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘long unsigned int’ [-Werror=format=]
     exfat_debug("start cluster %#x, size %#llx\n",
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  fsck.c:938:13: error: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘long unsigned int’ [-Werror=format=]
     exfat_err("invalid size of allocation bitmap. 0x%llx\n",
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  fsck.c:992:13: error: format ‘%llx’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘long unsigned int’ [-Werror=format=]
     exfat_err("invalid size of upcase table. 0x%llx\n",
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Peter Seiderer <ps.report@gmx.net>