### PR TITLE
fsck: fix node may be used uninitialized (fixes issue #51)

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -800,12 +800,12 @@ static int read_file_dentries(struct exfat_de_iter *iter,
 	ret = exfat_de_iter_get(iter, 0, &file_de);
 	if (ret || file_de->type != EXFAT_FILE) {
 		exfat_err("failed to get file dentry. %d\n", ret);
-		return ret;
+		return -EINVAL;
 	}
 	ret = exfat_de_iter_get(iter, 1, &stream_de);
 	if (ret || stream_de->type != EXFAT_STREAM) {
 		exfat_err("failed to get stream dentry. %d\n", ret);
-		return ret;
+		return -EINVAL;
 	}
 
 	*new_node = NULL;
@@ -824,6 +824,7 @@ static int read_file_dentries(struct exfat_de_iter *iter,
 		ret = exfat_de_iter_get(iter, i, &name_de);
 		if (ret || name_de->type != EXFAT_NAME) {
 			exfat_err("failed to get name dentry. %d\n", ret);
+			ret = -EINVAL;
 			goto err;
 		}
 
@@ -851,6 +852,7 @@ static int read_file_dentries(struct exfat_de_iter *iter,
 		exfat_err("valid size %llu greater than size %llu: %s\n",
 			le64_to_cpu(stream_de->stream_valid_size), node->size,
 			path_resolve_ctx.local_path);
+		ret = -EINVAL;
 		goto err;
 	}
 


### PR DESCRIPTION
The complicated way of gcc to tell not all failure pathes
set a return value != 0 in the calls before.

Fixes:

  fsck.c:1063:18: error: ‘node’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
       node->parent = dir;
                    ^
  fsck.c:871:22: note: ‘node’ was declared here
    struct exfat_inode *node;
                        ^

Signed-off-by: Peter Seiderer <ps.report@gmx.net>