### PR TITLE
mkfs: rename DEFAULT_CLUSTER_SIZE macro to DEFAULT_BOUNDARY_ALIGNMENT

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -409,14 +409,14 @@ static struct option opts[] = {
 static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
-	if (ui->cluster_size > DEFAULT_CLUSTER_SIZE)
+	if (ui->cluster_size > DEFAULT_BOUNDARY_ALIGNMENT)
 		finfo.fat_byte_off = ui->cluster_size;
 	else
-		finfo.fat_byte_off = DEFAULT_CLUSTER_SIZE;
+		finfo.fat_byte_off = DEFAULT_BOUNDARY_ALIGNMENT;
 	finfo.fat_byte_len = round_up((bd->num_clusters * sizeof(int)),
 		ui->cluster_size);
 	finfo.clu_byte_off = round_up(finfo.fat_byte_off + finfo.fat_byte_len,
-		DEFAULT_CLUSTER_SIZE);
+		DEFAULT_BOUNDARY_ALIGNMENT);
 	finfo.total_clu_cnt = (bd->size - finfo.clu_byte_off) /
 		ui->cluster_size;
 	if (finfo.total_clu_cnt > EXFAT_MAX_NUM_CLUSTER) {

--- a/mkfs/mkfs.h
+++ b/mkfs/mkfs.h
@@ -5,9 +5,9 @@
 
 #ifndef _MKFS_H
 
-#define DEFAULT_CLUSTER_SIZE	(1024*1024)
-#define MIN_NUM_SECTOR		(2048)
-#define EXFAT_MAX_CLUSTER_SIZE	(32*1024*1024)
+#define DEFAULT_BOUNDARY_ALIGNMENT	(1024*1024)
+#define MIN_NUM_SECTOR			(2048)
+#define EXFAT_MAX_CLUSTER_SIZE		(32*1024*1024)
 
 struct exfat_mkfs_info {
 	unsigned int total_clu_cnt;


### PR DESCRIPTION
Rename DEFAULT_CLUSTER_SIZE macro to DEFAULT_BOUNDARY_ALIGNMENT.
If needed, we can add the option to adjust boundary alignment so that
writes to these areas will happen in as few flash blocks as possible.

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>