### PR TITLE
Manpage fixes debian lintian

### DIFF
--- a/manpages/fsck.exfat.8
+++ b/manpages/fsck.exfat.8
@@ -19,7 +19,7 @@ fsck.exfat \- check an exFAT filesystem
 .B fsck.exfat \-V
 .SH DESCRIPTION
 .B fsck.exfat
-checks an exFAT filesystem and repairs the filesytem
+checks an exFAT filesystem and repairs the filesystem
 depending on the options passed.
 .PP
 .SH OPTIONS

--- a/manpages/tune.exfat.8
+++ b/manpages/tune.exfat.8
@@ -31,4 +31,3 @@ Prints verbose debugging information while extracting or tuning parameters of th
 .TP
 .B \-V
 Prints the version number and exits.
-.TP


### PR DESCRIPTION
While packaging exfatprogs for Debian our linter reported two minor issues with the manpages.

This PR is based on exfat-next and is geared to be merged into exfat-next.