### PR TITLE
Android.bp: add soong_namespace

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,5 +1,8 @@
 // Copyright 2020 The Android Open Source Project
 
+soong_namespace {
+}
+
 cc_library_headers {
     name: "libexfatprogs-headers",
     export_include_dirs: [


### PR DESCRIPTION
Make the blueprint namespace-aware so several exfat implementations
can coexist in a tree and chosen at build time.

Documentation on how to choose the namespace and use the feature
can be found here:

https://source.android.com/setup/build#namespace_modules


Signed-off-by: Pablo Mendez Hernandez <pablomh@gmail.com>