### PR TITLE
libexfat: Don't die getting the size of non-miniature devices

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -13,4 +13,5 @@ cc_defaults {
     name: "exfatprogs-defaults",
     header_libs: ["libexfatprogs-headers"],
     export_header_lib_headers: ["libexfatprogs-headers"],
+    cflags: ["-D_FILE_OFFSET_BITS=64"],
 }


### PR DESCRIPTION
* lseek() can only be used in this way when the overall size can
  be represented in an off_t. Whenever this is called against
  a block device of any reasonable size, it fails with EOVERFLOW.
* Member size in struct exfat_blk_dev is already an "unsigned long
  long", guaranteed to be at least 64 bits, so lseek64() and off64_t
  are a much more appropriate solution here.