### PR TITLE
exfatlabel: add get/set volume serial option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,24 @@ Usage example:
         tune.exfat -l /dev/sda1
     2. set new volume label.
         tune.exfat -L "new label" /dev/sda1
+    3. print current volume serial.
+        tune.exfat -i /dev/sda1
+    4. set new volume serial.
+        tune.exfat -I "new serial" /dev/sda1
 
 - exfatlabel:
-    Get or Set volume label
+    Get or Set volume label or serial
 
 Usage example:
     1. get current volume label.
         exfatlabel /dev/sda1
     2. set new volume label.
-        exfatlabel "new label" /dev/sda1
+        exfatlabel /dev/sda1 "new label"
+    3. get current volume serial.
+        exfatlabel -i /dev/sda1
+    4. set new volume serial.
+        exfatlabel -i /dev/sda1 "new serial"
+
 ```
 
 ## Benchmarks

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -37,6 +37,12 @@
 /* Upcase tabel macro */
 #define EXFAT_UPCASE_TABLE_SIZE		(5836)
 
+/* Flags for tune.exfat and exfatlabel */
+#define EXFAT_GET_VOLUME_LABEL		0x01
+#define EXFAT_SET_VOLUME_LABEL		0x02
+#define EXFAT_GET_VOLUME_SERIAL		0x03
+#define EXFAT_SET_VOLUME_SERIAL		0x04
+
 enum {
 	BOOT_SEC_IDX = 0,
 	EXBOOT_SEC_IDX,
@@ -65,6 +71,7 @@ struct exfat_user_input {
 	bool quick;
 	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
 	int volume_label_len;
+	unsigned int volume_serial;
 };
 
 void show_version(void);
@@ -90,6 +97,16 @@ off_t exfat_get_root_entry_offset(struct exfat_blk_dev *bd);
 int exfat_get_volume_label(struct exfat_blk_dev *bd, off_t root_clu_off);
 int exfat_set_volume_label(struct exfat_blk_dev *bd,
 		char *label_input, off_t root_clu_off);
+int exfat_read_sector(struct exfat_blk_dev *bd, void *buf,
+		unsigned int sec_off);
+int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
+		unsigned int sec_off);
+int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
+		unsigned int checksum, bool is_backup);
+int exfat_show_volume_serial(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui);
+int exfat_set_volume_serial(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui);
 
 /*
  * Exfat Print

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -94,7 +94,7 @@ ssize_t exfat_utf16_enc(const char *in_str, __u16 *out_str, size_t out_size);
 ssize_t exfat_utf16_dec(const __u16 *in_str, size_t in_len,
 			char *out_str, size_t out_size);
 off_t exfat_get_root_entry_offset(struct exfat_blk_dev *bd);
-int exfat_get_volume_label(struct exfat_blk_dev *bd, off_t root_clu_off);
+int exfat_show_volume_label(struct exfat_blk_dev *bd, off_t root_clu_off);
 int exfat_set_volume_label(struct exfat_blk_dev *bd,
 		char *label_input, off_t root_clu_off);
 int exfat_read_sector(struct exfat_blk_dev *bd, void *buf,

--- a/label/label.c
+++ b/label/label.c
@@ -17,6 +17,7 @@
 static void usage(void)
 {
 	fprintf(stderr, "Usage: exfatlabel\n");
+	fprintf(stderr, "\t-i | --volume-serial                  Switch to volume serial mode\n");
 	fprintf(stderr, "\t-V | --version                        Show version\n");
 	fprintf(stderr, "\t-h | --help                           Show help\n");
 
@@ -24,6 +25,7 @@ static void usage(void)
 }
 
 static struct option opts[] = {
+	{"volume-serial",	no_argument,		NULL,	'i' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"help",		no_argument,		NULL,	'h' },
 	{"?",			no_argument,		NULL,	'?' },
@@ -38,15 +40,30 @@ int main(int argc, char *argv[])
 	struct exfat_user_input ui;
 	bool version_only = false;
 	off_t root_clu_off;
+	int serial_mode = 0;
+	int flags = 0;
 
 	init_user_input(&ui);
 
 	if (!setlocale(LC_CTYPE, ""))
 		exfat_err("failed to init locale/codeset\n");
 
+	if (argc == 2)
+		flags = EXFAT_GET_VOLUME_LABEL;
+	else if (argc == 3)
+		flags = EXFAT_SET_VOLUME_LABEL;
+
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "Vh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "iVh", opts, NULL)) != EOF)
 		switch (c) {
+		case 'i':
+			serial_mode = true;
+			if (argc == 3)
+				flags = EXFAT_GET_VOLUME_SERIAL;
+			else if (argc == 4)
+				flags = EXFAT_SET_VOLUME_SERIAL;
+
+			break;
 		case 'V':
 			version_only = true;
 			break;
@@ -64,20 +81,31 @@ int main(int argc, char *argv[])
 		usage();
 
 	memset(ui.dev_name, 0, sizeof(ui.dev_name));
-	snprintf(ui.dev_name, sizeof(ui.dev_name), "%s", argv[1]);
+	snprintf(ui.dev_name, sizeof(ui.dev_name), "%s", argv[serial_mode + 1]);
 
 	ret = exfat_get_blk_dev_info(&ui, &bd);
 	if (ret < 0)
 		goto out;
 
-	root_clu_off = exfat_get_root_entry_offset(&bd);
-	if (root_clu_off < 0)
-		goto out;
+	if (serial_mode) {
+		/* Mode to change or display volume serial */
+		if (flags == EXFAT_GET_VOLUME_SERIAL) {
+			ret = exfat_show_volume_serial(&bd, &ui);
+		} else if (flags == EXFAT_SET_VOLUME_SERIAL) {
+			ui.volume_serial = strtoul(argv[3], NULL, 0);
+			ret = exfat_set_volume_serial(&bd, &ui);
+		}
+	} else {
+		/* Mode to change or display volume label */
+		root_clu_off = exfat_get_root_entry_offset(&bd);
+		if (root_clu_off < 0)
+			goto out;
 
-	if (argc == 2)
-		ret = exfat_get_volume_label(&bd, root_clu_off);
-	else
-		ret = exfat_set_volume_label(&bd, argv[2], root_clu_off);
+		if (flags == EXFAT_GET_VOLUME_LABEL)
+			ret = exfat_get_volume_label(&bd, root_clu_off);
+		else if (flags == EXFAT_SET_VOLUME_LABEL)
+			ret = exfat_set_volume_label(&bd, argv[2], root_clu_off);
+	}
 
 out:
 	return ret;

--- a/label/label.c
+++ b/label/label.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 			goto out;
 
 		if (flags == EXFAT_GET_VOLUME_LABEL)
-			ret = exfat_get_volume_label(&bd, root_clu_off);
+			ret = exfat_show_volume_label(&bd, root_clu_off);
 		else if (flags == EXFAT_SET_VOLUME_LABEL)
 			ret = exfat_set_volume_label(&bd, argv[2], root_clu_off);
 	}

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -356,7 +356,7 @@ off_t exfat_get_root_entry_offset(struct exfat_blk_dev *bd)
 	return root_clu_off;
 }
 
-int exfat_get_volume_label(struct exfat_blk_dev *bd, off_t root_clu_off)
+int exfat_show_volume_label(struct exfat_blk_dev *bd, off_t root_clu_off)
 {
 	struct exfat_dentry *vol_entry;
 	char volume_label[VOLUME_LABEL_BUFFER_SIZE];

--- a/manpages/exfatlabel.8
+++ b/manpages/exfatlabel.8
@@ -1,14 +1,17 @@
 .TH exfatlabel 8
 .SH NAME
-exfatlabel \- Get or Set volume label of an exFAT filesystem
+exfatlabel \- Get or Set volume label or volume serial of an exFAT filesystem
 .SH SYNOPSIS
 .B exfatlabel
 [
+.B \-i
+.I volume-label
+] [
 .B \-v
 ]
 .I device
 [
-.I label_string
+.I label_string or serial_value
 ]
 .br
 .B exfatlabel \-V
@@ -20,9 +23,14 @@ If there is a
 .I label_string
 in argument of exfatlabel, It will be written to volume label
 field on given device. If not, exfatlabel will just print out
-after reading volume label field from given device.
+after reading volume label field from given device. If -i or
+--volume-serial is given, It can be switched to volume serial
+mode.
 .PP
 .SH OPTIONS
+.TP
+.BI \-i
+Switch to volume serial mode.
 .TP
 .B \-V
 Prints the version number and exits.

--- a/manpages/tune.exfat.8
+++ b/manpages/tune.exfat.8
@@ -5,9 +5,16 @@ tune.exfat \- adjust tunable filesystem parameters on an exFAT filesystem
 .B tune.exfat
 [
 .B \-l
+.I print-label
 ] [
-.B \-L volume_label
-.I volume_label
+.B \-L
+.I set-label
+] [
+.B \-i
+.I print-serial
+] [
+.B \-I
+.I set-serial
 ] [
 .B \-v
 ]
@@ -20,12 +27,18 @@ adjust tunable ondisk parameters of an existing exFAT filesystem.
 .PP
 .SH OPTIONS
 .TP
-.BI \-l
+.BI \-l " print-label"
 Print the volume label of the exFAT filesystem.
 .TP
-.BI \-L" volume_label"
+.BI \-L " set-label"
 Set the volume label of the filesystem to the provided argument.
 .TP
+.TP
+.BI \-i " print-serial"
+Print the volume serial of the exFAT filesystem.
+.TP
+.BI \-I " set-serial"
+Set the volume serial of the filesystem to the provided argument.
 .BI \-v
 Prints verbose debugging information while extracting or tuning parameters of the exFAT filesystem.
 .TP

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -88,26 +88,11 @@ static void exfat_setup_boot_sector(struct pbr *ppbr,
 		le32_to_cpu(pbsx->clu_count));
 	exfat_debug("Root Cluster (cluster offset) : %u\n",
 		le32_to_cpu(pbsx->root_cluster));
+	exfat_debug("Volume Serial : 0x%x\n", le32_to_cpu(pbsx->vol_serial));
 	exfat_debug("Sector Size Bits : %u\n",
 		pbsx->sect_size_bits);
 	exfat_debug("Sector per Cluster bits : %u\n",
 		pbsx->sect_per_clus_bits);
-}
-
-static int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
-		unsigned int sec_off)
-{
-	int bytes;
-	unsigned long long offset = sec_off * bd->sector_size;
-
-	lseek(bd->dev_fd, offset, SEEK_SET);
-	bytes = write(bd->dev_fd, buf, bd->sector_size);
-	if (bytes != (int)bd->sector_size) {
-		exfat_err("write failed, sec_off : %u, bytes : %d\n", sec_off,
-			bytes);
-		return -1;
-	}
-	return 0;
 }
 
 static int exfat_write_boot_sector(struct exfat_blk_dev *bd,
@@ -210,35 +195,6 @@ static int exfat_write_oem_sector(struct exfat_blk_dev *bd,
 
 free_oem:
 	free(oem);
-	return ret;
-}
-
-static int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
-		unsigned int checksum, bool is_backup)
-{
-	__le32 *checksum_buf;
-	int ret = 0;
-	unsigned int i;
-	unsigned int sec_idx = CHECKSUM_SEC_IDX;
-
-	checksum_buf = malloc(bd->sector_size);
-	if (!checksum_buf)
-		return -1;
-
-	if (is_backup)
-		sec_idx += BACKUP_BOOT_SEC_IDX;
-
-	for (i = 0; i < bd->sector_size / sizeof(int); i++)
-		checksum_buf[i] = cpu_to_le32(checksum);
-
-	ret = exfat_write_sector(bd, checksum_buf, sec_idx);
-	if (ret) {
-		exfat_err("checksum sector write failed\n");
-		goto free;
-	}
-
-free:
-	free(checksum_buf);
 	return ret;
 }
 

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -114,7 +114,7 @@ int main(int argc, char *argv[])
 		goto out;
 
 	if (flags == EXFAT_GET_VOLUME_LABEL)
-		ret = exfat_get_volume_label(&bd, root_clu_off);
+		ret = exfat_show_volume_label(&bd, root_clu_off);
 	else if (flags == EXFAT_SET_VOLUME_LABEL)
 		ret = exfat_set_volume_label(&bd, label_input, root_clu_off);
 

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -18,7 +18,9 @@ static void usage(void)
 {
 	fprintf(stderr, "Usage: tune.exfat\n");
 	fprintf(stderr, "\t-l | --print-label                    Print volume label\n");
-	fprintf(stderr, "\t-L | --volume-label=label             Set volume label\n");
+	fprintf(stderr, "\t-L | --set-label=label                Set volume label\n");
+	fprintf(stderr, "\t-i | --print-serial                   Print volume serial\n");
+	fprintf(stderr, "\t-L | --set-serial=value               Set volume serial\n");
 	fprintf(stderr, "\t-V | --version                        Show version\n");
 	fprintf(stderr, "\t-v | --verbose                        Print debug\n");
 	fprintf(stderr, "\t-h | --help                           Show help\n");
@@ -29,15 +31,14 @@ static void usage(void)
 static struct option opts[] = {
 	{"print-label",		no_argument,		NULL,	'l' },
 	{"set-label",		required_argument,	NULL,	'L' },
+	{"print-serial",	no_argument,		NULL,	'i' },
+	{"set-serial",		required_argument,	NULL,	'I' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"verbose",		no_argument,		NULL,	'v' },
 	{"help",		no_argument,		NULL,	'h' },
 	{"?",			no_argument,		NULL,	'?' },
 	{NULL,			0,			NULL,	 0  }
 };
-
-#define EXFAT_GET_LABEL	0x1
-#define EXFAT_SET_LABEL	0x2
 
 int main(int argc, char *argv[])
 {
@@ -56,15 +57,22 @@ int main(int argc, char *argv[])
 		exfat_err("failed to init locale/codeset\n");
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "L:lVvh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "I:iL:lVvh", opts, NULL)) != EOF)
 		switch (c) {
 		case 'l':
-			flags = EXFAT_GET_LABEL;
+			flags = EXFAT_GET_VOLUME_LABEL;
 			break;
 		case 'L':
 			snprintf(label_input, sizeof(label_input), "%s",
 					optarg);
-			flags = EXFAT_SET_LABEL;
+			flags = EXFAT_SET_VOLUME_LABEL;
+			break;
+		case 'i':
+			flags = EXFAT_GET_VOLUME_SERIAL;
+			break;
+		case 'I':
+			ui.volume_serial = strtoul(optarg, NULL, 0);
+			flags = EXFAT_SET_VOLUME_SERIAL;
 			break;
 		case 'V':
 			version_only = true;
@@ -92,13 +100,22 @@ int main(int argc, char *argv[])
 	if (ret < 0)
 		goto out;
 
+	/* Mode to change or display volume serial */
+	if (flags == EXFAT_GET_VOLUME_SERIAL) {
+		ret = exfat_show_volume_serial(&bd, &ui);
+		goto out;
+	} else if (flags == EXFAT_SET_VOLUME_SERIAL) {
+		ret = exfat_set_volume_serial(&bd, &ui);
+		goto out;
+	}
+
 	root_clu_off = exfat_get_root_entry_offset(&bd);
 	if (root_clu_off < 0)
 		goto out;
 
-	if (flags == EXFAT_GET_LABEL)
+	if (flags == EXFAT_GET_VOLUME_LABEL)
 		ret = exfat_get_volume_label(&bd, root_clu_off);
-	else if (flags == EXFAT_SET_LABEL)
+	else if (flags == EXFAT_SET_VOLUME_LABEL)
 		ret = exfat_set_volume_label(&bd, label_input, root_clu_off);
 
 out:


### PR DESCRIPTION
Add get/set volume serial option in exfatlabel and tune.exfat

$ sudo exfatlabel -i /dev/sdb1 0x1234
exfatprogs version : 1.0.4
New volume serial : 0x1234

$ sudo exfatlabel -i /dev/sdb1
exfatprogs version : 1.0.4
volume serial : 0x1234

Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>