### PR TITLE
mkfs: avoid integer truncation when bounds checking cluster count

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -429,6 +429,7 @@ static struct option opts[] = {
 static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
+	unsigned long long total_clu_cnt;
 	int clu_len;
 
 	if (ui->boundary_align < bd->sector_size) {
@@ -446,12 +447,12 @@ static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 		exfat_err("boundary alignment is too big\n");
 		return -1;
 	}
-	finfo.total_clu_cnt = (bd->size - finfo.clu_byte_off) /
-		ui->cluster_size;
-	if (finfo.total_clu_cnt > EXFAT_MAX_NUM_CLUSTER) {
+	total_clu_cnt = (bd->size - finfo.clu_byte_off) / ui->cluster_size;
+	if (total_clu_cnt > EXFAT_MAX_NUM_CLUSTER) {
 		exfat_err("cluster size is too small\n");
 		return -1;
 	}
+	finfo.total_clu_cnt = (unsigned int) total_clu_cnt;
 
 	finfo.bitmap_byte_off = finfo.clu_byte_off;
 	finfo.bitmap_byte_len = round_up(finfo.total_clu_cnt, 8) / 8;


### PR DESCRIPTION
The bounds check on the number of data clusters in `mkfs.exfat` is subject to an integer truncation that would in most cases prevent the check from catching an out-of-bounds cluster count. This PR fixes the bounds check by moving the truncation to after the check.

Specifically: `finfo.total_clu_cnt` has type `unsigned int`, but `bd->size` has type `unsigned long long`, and the quotient resulting from the division may be wider than an `unsigned int`. Only the low bits of the quotient are compared against `EXFAT_MAX_NUM_CLUSTER`, but that will fail to catch most cases of the cluster size being too small for the volume size.