### PR TITLE
mkfs: set vol_offset field and compensate for volume offset in alignment

### DIFF
--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -49,6 +49,7 @@ enum {
 
 struct exfat_blk_dev {
 	int dev_fd;
+	unsigned long long offset;
 	unsigned long long size;
 	unsigned int sector_size;
 	unsigned int sector_size_bits;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -53,7 +53,7 @@ static void exfat_setup_boot_sector(struct pbr *ppbr,
 	memset(pbpb->res_zero, 0, 53);
 
 	/* Fill exfat extend BIOS paramemter block */
-	pbsx->vol_offset = 0;
+	pbsx->vol_offset = cpu_to_le64(bd->offset / bd->sector_size);
 	pbsx->vol_length = cpu_to_le64(bd->size / bd->sector_size);
 	pbsx->fat_offset = cpu_to_le32(finfo.fat_byte_off / bd->sector_size);
 	pbsx->fat_length = cpu_to_le32(finfo.fat_byte_len / bd->sector_size);
@@ -76,6 +76,8 @@ static void exfat_setup_boot_sector(struct pbr *ppbr,
 	memset(ppbr->boot_code, 0, 390);
 	ppbr->signature = cpu_to_le16(PBR_SIGNATURE);
 
+	exfat_debug("Volume Offset(sectors) : %" PRIu64 "\n",
+		le64_to_cpu(pbsx->vol_offset));
 	exfat_debug("Volume Length(sectors) : %" PRIu64 "\n",
 		le64_to_cpu(pbsx->vol_length));
 	exfat_debug("FAT Offset(sector offset) : %u\n",
@@ -436,12 +438,12 @@ static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 				bd->sector_size);
 		return -1;
 	}
-	finfo.fat_byte_off = round_up(24 * bd->sector_size,
-			ui->boundary_align);
+	finfo.fat_byte_off = round_up(bd->offset + 24 * bd->sector_size,
+			ui->boundary_align) - bd->offset;
 	finfo.fat_byte_len = round_up((bd->num_clusters * sizeof(int)),
 		ui->cluster_size);
-	finfo.clu_byte_off = round_up(finfo.fat_byte_off + finfo.fat_byte_len,
-		ui->boundary_align);
+	finfo.clu_byte_off = round_up(bd->offset + finfo.fat_byte_off +
+		finfo.fat_byte_len, ui->boundary_align) - bd->offset;
 	if (bd->size <= finfo.clu_byte_off) {
 		exfat_err("boundary alignment is too big\n");
 		return -1;


### PR DESCRIPTION
The `vol_offset` field of the exFAT superblock is supposed to contain the number of sectors preceding the exFAT volume on the storage medium. This will rightly be zero only if the exFAT file system is being created on an unpartitioned block device. When created on a partition, though, the actual volume offset will be non-zero, and this ought to be reflected in the `vol_offset` field of the exFAT superblock.

The Linux kernel exposes a partition's offset through sysfs at `/sys/dev/block/<major>:<minor>/start`. This PR teaches `mkfs` to attempt to read that file and, if successful, to set the `vol_offset` field of the exFAT superblock accordingly.

Additionally, this PR adjusts the boundary alignment calculations to compensate for the volume offset. This corrects the placement of the FAT and data regions so that they are located at multiples of the boundary alignment on the *medium* even when the *partition* does not begin at a multiple of the boundary alignment.

Take as a common example a flash drive with a partition beginning at sector 2048 (1 MiB) and with a 4-MiB allocation unit. Prior to this PR, when run with a boundary alignment of 4M, `mkfs` would place the FAT region at sector 8192 of the *partition* device, corresponding to sector 10240 of the whole drive — not a multiple of the 4-MiB allocation unit! After merging this PR, `mkfs` would place the FAT region at sector 6144 of the partition device, corresponding to sector 8192 of the drive.