### PR TITLE
mkfs: place bitmap immediately before alignment boundary if possible

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -426,6 +426,37 @@ static struct option opts[] = {
 	{NULL,			0,			NULL,	 0  }
 };
 
+/*
+ * Moves the bitmap to just before the alignment boundary if there is space
+ * between the boundary and the end of the FAT. This may allow the FAT and the
+ * bitmap to share the same allocation unit on flash media, thereby improving
+ * performance and endurance.
+ */
+static int exfat_pack_bitmap(const struct exfat_user_input *ui) {
+	unsigned int fat_byte_end = finfo.fat_byte_off + finfo.fat_byte_len,
+		bitmap_byte_len = finfo.bitmap_byte_len,
+		bitmap_clu_len = round_up(bitmap_byte_len, ui->cluster_size),
+		bitmap_clu_cnt, total_clu_cnt, new_bitmap_clu_len;
+	for (;;) {
+		bitmap_clu_cnt = bitmap_clu_len / ui->cluster_size;
+		if (finfo.clu_byte_off - bitmap_clu_len < fat_byte_end ||
+				finfo.total_clu_cnt > EXFAT_MAX_NUM_CLUSTER -
+					bitmap_clu_cnt)
+			return -1;
+		total_clu_cnt = finfo.total_clu_cnt + bitmap_clu_cnt;
+		bitmap_byte_len = round_up(total_clu_cnt, 8) / 8;
+		new_bitmap_clu_len = round_up(bitmap_byte_len, ui->cluster_size);
+		if (new_bitmap_clu_len == bitmap_clu_len) {
+			finfo.clu_byte_off -= bitmap_clu_len;
+			finfo.total_clu_cnt = total_clu_cnt;
+			finfo.bitmap_byte_off -= bitmap_clu_len;
+			finfo.bitmap_byte_len = bitmap_byte_len;
+			return 0;
+		}
+		bitmap_clu_len = new_bitmap_clu_len;
+	}
+}
+
 static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
@@ -455,6 +486,7 @@ static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 
 	finfo.bitmap_byte_off = finfo.clu_byte_off;
 	finfo.bitmap_byte_len = round_up(finfo.total_clu_cnt, 8) / 8;
+	exfat_pack_bitmap(ui);
 	clu_len = round_up(finfo.bitmap_byte_len, ui->cluster_size);
 
 	finfo.ut_start_clu = EXFAT_FIRST_CLUSTER + clu_len / ui->cluster_size;


### PR DESCRIPTION
Prior to this PR, when the boundary alignment of `mkfs.exfat` is set to the allocation unit of flash media, then the FAT and the bitmap end up in different allocation units. This can have a deleterious effect on performance and endurance of some flash media. This commit adds an opportunistic attempt to move the bitmap to just before the alignment boundary (instead of just after it) to allow the FAT and the bitmap to share an allocation unit where possible. If there is insufficient space between the end of the FAT and the next alignment boundary, or if moving the bitmap into that space would cause the number of data clusters to exceed `EXFAT_MAX_NUM_CLUSTER`, then the old behavior is maintained: the bitmap is placed beginning at an alignment boundary.

## Case study

I have a 128GB SDXC card having 251,394,048 sectors. The factory partition begins at sector 32768 and so has a size of 251,361,280 sectors. Using a default cluster size of 128 KiB, the FAT size is 3840 KiB. The erase-block size of this card is 4 MiB (according to `/sys/class/mmc_host/mmc0/mmc0:*/preferred_erased_size`), so I pass `-b 4M` to `mkfs.exfat`.

### Previous behavior:
* FAT begins at sector 8192 (an alignment boundary)
* FAT ends just before sector 15872
* Bitmap's cluster allocation begins at sector 16384 (an alignment boundary)
* Bitmap's cluster allocation ends just before sector 16640
* Upcase table's cluster allocation begins at sector 16640
* Upcase table's cluster allocation ends just before sector 16896
* Root directory's cluster allocation begins at sector 16896

### New behavior:
* FAT begins at sector 8192 (an alignment boundary)
* FAT ends just before sector 15872
* Bitmap's cluster allocation begins at sector **16128**
* Bitmap's cluster allocation ends just before sector **16384 (an alignment boundary)**
* Upcase table's cluster allocation begins at sector **16384 (an alignment boundary)**
* Upcase table's cluster allocation ends just before sector **16640**
* Root directory's cluster allocation begins at sector **16640**

The new behavior has the advantage that the FAT and the bitmap are both located entirely within the single 4-MiB allocation unit that spans from sector 8192 to sector 16384. Thus, when subsequently allocating/deallocating files on this file system, both the FAT and the bitmap will be updated by writing to a single allocation unit on the SD card. Reducing the number of allocation units touched by a write access pattern improves performance and endurance by reducing the number of garbage collections that the flash controller must perform.