### PR TITLE
Three fixes and enhancements to mkfs

### DIFF
--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -70,6 +70,7 @@ struct exfat_user_input {
 	unsigned int cluster_size;
 	unsigned int sec_per_clu;
 	unsigned int boundary_align;
+	bool pack_bitmap;
 	bool quick;
 	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
 	int volume_label_len;

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -55,6 +55,7 @@ enum {
 
 struct exfat_blk_dev {
 	int dev_fd;
+	unsigned long long offset;
 	unsigned long long size;
 	unsigned int sector_size;
 	unsigned int sector_size_bits;

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -164,17 +164,20 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 	}
 
 	if (fstat(fd, &st) == 0 && S_ISBLK(st.st_mode)) {
-		char pathname[43];
+		char pathname[sizeof("/sys/dev/block/4294967295:4294967295/start")];
 		FILE *fp;
-		snprintf(pathname, sizeof pathname, "/sys/dev/block/%u:%u/start",
+
+		snprintf(pathname, sizeof(pathname), "/sys/dev/block/%u:%u/start",
 			major(st.st_rdev), minor(st.st_rdev));
-		if ((fp = fopen(pathname, "r")) != NULL) {
-			if (fscanf(fp, "%llu", &blk_dev_offset) == 1)
+		fp = fopen(pathname, "r");
+		if (fp != NULL) {
+			if (fscanf(fp, "%llu", &blk_dev_offset) == 1) {
 				/*
 				 * Linux kernel always reports partition offset
 				 * in 512-byte units, regardless of sector size
 				 */
 				blk_dev_offset <<= 9;
+			}
 			fclose(fp);
 		}
 	}

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -39,30 +39,53 @@ SCSI disk, use:
 .PP
 .SH OPTIONS
 .TP
-.BI \-b " boundary_alignment"
-Specify the alignment for FAT and start of cluster.
-Boundary alignment can be specified in m/M for megabytes
-and k/K for kilobytes. It should be a power of two.
-Some media like sdcard need this.
+.BR \-b ", " \-\-boundary\-align =\fIalignment\fR
+Specifies the alignment for the FAT and the start of the cluster heap.
+The \fIalignment\fR argument is specified in bytes or may be specified with
+\fBm\fR/\fBM\fR suffix for mebibytes or \fBk\fR/\fBK\fR suffix for kibibytes
+and should be a power of two.
+Some media like SD cards need this for optimal performance and endurance,
+in which case \fIalignment\fR should be set to half of the card's native
+boundary unit size.
+If the card's native boundary unit size is not known, refer to the following
+table of boundary unit sizes recommended by the SD Card Association.
+.\" source: SD Specifications Part 2: File System Specification Version 3.00
+.TS
+center;
+cb1s6cbcb,nnnn.
+Card Capacity Range	Cluster Size	Boundary Unit
+_
+	\[<=]8 MiB	8 KiB	8 KiB
+>8 MiB	\[<=]64 MiB	16 KiB	16 KiB
+>64 MiB	\[<=]256 MiB	16 KiB	32 KiB
+>256 MiB	\[<=]1 GiB	16 KiB	64 KiB
+>1 GiB	\[<=]2 GiB	32 KiB	64 KiB
+>2 GiB	\[<=]32 GiB	32 KiB	4 MiB
+>32 GiB	\[<=]128 GiB	128 KiB	16 MiB
+>128 GiB	\[<=]512 GiB	256 KiB	32 MiB
+>512 GiB	\[<=]2 TiB	512 KiB	64 MiB
+.TE
 .TP
-.BI \-c " cluster_size"
-Specify the cluster size. Cluster size can be specified in m/M for megabytes
-and k/K for kilobytes.
+.BR \-c ", " \-\-cluster\-size =\fIsize\fR
+Specifies the cluster size of the exFAT file system.
+The \fIsize\fR argument is specified in bytes or may be specified with
+\fBm\fR/\fBM\fR suffix for mebibytes or \fBk\fR/\fBK\fR suffix for kibibytes
+and must be a power of two.
 .TP
-.BI \-f
-Performs a full format. This zeros the entire disk device while
-creating the exFAT filesystem.
+.BR \-f ", " \-\-full\-format
+Performs a full format.
+This zeros the entire disk device while creating the exFAT filesystem.
 .TP
-.BI \-h
+.BR \-h ", " \-\-help
 Prints the help and exit.
 .TP
-.BI \-L " volume_label"
-Specifies the volume label associated with the exFAT filesystem.
+.BR \-L ", " \-\-volume\-label =\fIlabel\fR
+Specifies the volume label to be associated with the exFAT filesystem.
 .TP
-.BI \-v
+.BR \-v ", " \-\-verbose
 Prints verbose debugging information while creating the exFAT filesystem.
 .TP
-.B \-V
+.BR \-V ", " \-\-version
 Prints the version number and exits.
 .SH SEE ALSO
 .BR mkfs (8),

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -17,6 +17,8 @@ mkfs.exfat \- create an exFAT filesystem
 .B \-L
 .I volume_label
 ] [
+.B \-\-pack\-bitmap
+] [
 .B \-v
 ]
 .I device
@@ -81,6 +83,23 @@ Prints the help and exit.
 .TP
 .BR \-L ", " \-\-volume\-label =\fIlabel\fR
 Specifies the volume label to be associated with the exFAT filesystem.
+.TP
+.B \-\-pack\-bitmap
+Attempts to relocate the exFAT allocation bitmap so that it ends at the
+alignment boundary immediately following the FAT rather than beginning at that
+boundary.
+This strictly violates the SD card specification but may improve performance
+and endurance on SD cards and other flash media not designed for use with exFAT
+by allowing file-system metadata updates to touch fewer flash allocation units.
+Furthermore, many SD cards and other flash devices specially optimize the
+allocation unit where the FAT resides so as to support tiny writes with reduced
+write amplification but expect only larger writes in subsequent allocation
+units \[em] where the exFAT bitmap would be placed by default.
+Specifying \fB\-\-pack\-bitmap\fR attempts to avoid the potential problems
+associated with issuing many small writes to the bitmap by making it share an
+allocation unit with the FAT.
+If there is insufficient space for the bitmap there, then this option will have
+no effect, and the bitmap will be aligned at the boundary as by default.
 .TP
 .BR \-v ", " \-\-verbose
 Prints verbose debugging information while creating the exFAT filesystem.

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -375,9 +375,7 @@ static void usage(void)
 	exit(EXIT_FAILURE);
 }
 
-enum LongOption {
-	PACK_BITMAP = CHAR_MAX + 1,
-};
+#define PACK_BITMAP (CHAR_MAX + 1)
 
 static const struct option opts[] = {
 	{"volume-label",	required_argument,	NULL,	'L' },
@@ -398,11 +396,13 @@ static const struct option opts[] = {
  * bitmap to share the same allocation unit on flash media, thereby improving
  * performance and endurance.
  */
-static int exfat_pack_bitmap(const struct exfat_user_input *ui) {
+static int exfat_pack_bitmap(const struct exfat_user_input *ui)
+{
 	unsigned int fat_byte_end = finfo.fat_byte_off + finfo.fat_byte_len,
 		bitmap_byte_len = finfo.bitmap_byte_len,
 		bitmap_clu_len = round_up(bitmap_byte_len, ui->cluster_size),
 		bitmap_clu_cnt, total_clu_cnt, new_bitmap_clu_len;
+
 	for (;;) {
 		bitmap_clu_cnt = bitmap_clu_len / ui->cluster_size;
 		if (finfo.clu_byte_off - bitmap_clu_len < fat_byte_end ||

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -385,6 +385,7 @@ static struct option opts[] = {
 static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
+	unsigned long long total_clu_cnt;
 	int clu_len;
 
 	if (ui->boundary_align < bd->sector_size) {
@@ -402,12 +403,12 @@ static int exfat_build_mkfs_info(struct exfat_blk_dev *bd,
 		exfat_err("boundary alignment is too big\n");
 		return -1;
 	}
-	finfo.total_clu_cnt = (bd->size - finfo.clu_byte_off) /
-		ui->cluster_size;
-	if (finfo.total_clu_cnt > EXFAT_MAX_NUM_CLUSTER) {
+	total_clu_cnt = (bd->size - finfo.clu_byte_off) / ui->cluster_size;
+	if (total_clu_cnt > EXFAT_MAX_NUM_CLUSTER) {
 		exfat_err("cluster size is too small\n");
 		return -1;
 	}
+	finfo.total_clu_cnt = (unsigned int) total_clu_cnt;
 
 	finfo.bitmap_byte_off = finfo.clu_byte_off;
 	finfo.bitmap_byte_len = round_up(finfo.total_clu_cnt, 8) / 8;


### PR DESCRIPTION
This PR consists of three fixes and enhancements to `mkfs`, grouped into a single PR by [request](https://github.com/exfatprogs/exfatprogs/pull/142#issuecomment-774788255).

* **mkfs: avoid integer truncation when bounds checking cluster count** (formerly #143)

  The bounds check on the number of data clusters in `mkfs.exfat` is subject to an integer truncation that would in most cases prevent the check from catching an out-of-bounds cluster count. This PR fixes the bounds check by moving the truncation to after the check.

  Specifically: `finfo.total_clu_cnt` has type `unsigned int`, but `bd->size` has type `unsigned long long`, and the quotient resulting from the division may be wider than an `unsigned int`. Only the low bits of the quotient are compared against `EXFAT_MAX_NUM_CLUSTER`, but that will fail to catch most cases of the cluster size being too small for the volume size.

* **mkfs: set vol_offset field and compensate for volume offset in alignment** (formerly #144)

  The `vol_offset` field of the exFAT superblock is supposed to contain the number of sectors preceding the exFAT volume on the storage medium. This will rightly be zero only if the exFAT file system is being created on an unpartitioned block device. When created on a partition, though, the actual volume offset will be non-zero, and this ought to be reflected in the `vol_offset` field of the exFAT superblock.

  The Linux kernel exposes a partition's offset through sysfs at `/sys/dev/block/<major>:<minor>/start`. This PR teaches `mkfs` to attempt to read that file and, if successful, to set the `vol_offset` field of the exFAT superblock accordingly.

  Additionally, this PR adjusts the boundary alignment calculations to compensate for the volume offset. This corrects the placement of the FAT and data regions so that they are located at multiples of the boundary alignment on the *medium* even when the *partition* does not begin at a multiple of the boundary alignment.

  Take as a common example a flash drive with a partition beginning at sector 2048 (1 MiB) and with a 4-MiB allocation unit. Prior to this PR, when run with a boundary alignment of 4M, `mkfs` would place the FAT region at sector 8192 of the *partition* device, corresponding to sector 10240 of the whole drive — not a multiple of the 4-MiB allocation unit! After merging this PR, `mkfs` would place the FAT region at sector 6144 of the partition device, corresponding to sector 8192 of the drive.

* **mkfs: place bitmap immediately before alignment boundary if possible** (formerly #145)

  Prior to this PR, when the boundary alignment of `mkfs.exfat` is set to the allocation unit of flash media, then the FAT and the bitmap end up in different allocation units. This can have a deleterious effect on performance and endurance of some flash media. This commit adds an opportunistic attempt to move the bitmap to just before the alignment boundary (instead of just after it) to allow the FAT and the bitmap to share an allocation unit where possible. If there is insufficient space between the end of the FAT and the next alignment boundary, or if moving the bitmap into that space would cause the number of data clusters to exceed `EXFAT_MAX_NUM_CLUSTER`, then the old behavior is maintained: the bitmap is placed beginning at an alignment boundary.

  ## Case study

  I have a 128GB SDXC card having 251,394,048 sectors. The factory partition begins at sector 32768 and so has a size of 251,361,280 sectors. Using a default cluster size of 128 KiB, the FAT size is 3840 KiB. The erase-block size of this card is 4 MiB (according to `/sys/class/mmc_host/mmc0/mmc0:*/preferred_erased_size`), so I pass `-b 4M` to `mkfs.exfat`.

  ### Previous behavior:
  * FAT begins at sector 8192 (an alignment boundary)
  * FAT ends just before sector 15872
  * Bitmap's cluster allocation begins at sector 16384 (an alignment boundary)
  * Bitmap's cluster allocation ends just before sector 16640
  * Upcase table's cluster allocation begins at sector 16640
  * Upcase table's cluster allocation ends just before sector 16896
  * Root directory's cluster allocation begins at sector 16896

  ### New behavior:
  * FAT begins at sector 8192 (an alignment boundary)
  * FAT ends just before sector 15872
  * Bitmap's cluster allocation begins at sector **16128**
  * Bitmap's cluster allocation ends just before sector **16384 (an alignment boundary)**
  * Upcase table's cluster allocation begins at sector **16384 (an alignment boundary)**
  * Upcase table's cluster allocation ends just before sector **16640**
  * Root directory's cluster allocation begins at sector **16640**

  The new behavior has the advantage that the FAT and the bitmap are both located entirely within the single 4-MiB allocation unit that spans from sector 8192 to sector 16384. Thus, when subsequently allocating/deallocating files on this file system, both the FAT and the bitmap will be updated by writing to a single allocation unit on the SD card. Reducing the number of allocation units touched by a write access pattern improves performance and endurance by reducing the number of garbage collections that the flash controller must perform.

  @namjaejeon [wrote](https://github.com/exfatprogs/exfatprogs/pull/145#issuecomment-774807252):
  > Do you have any data for performance and endurance when applying this patch?

  I do not. I can't imagine it can be any worse, though, as in all cases it results in either a reduction in the number of AUs modified for a FAT+bitmap update or no change in the number of AUs modified.

  @namjaejeon [wrote](https://github.com/exfatprogs/exfatprogs/pull/145#issuecomment-774809656):
  > exfat wiki describe boundary alignment as the following. (https://en.wikipedia.org/wiki/ExFAT)
  > 
  >> Boundary alignment for filesystem structures. The offsets for the FAT and the cluster heap is adjustable at format-time, so that writes to these areas will happen in as few flash blocks as possible.
  > 
  > It means cluster heap(bitmap offset) and fat offset should be aligned with boundary alignment offset.

  That's not what it says, though. It says that the offsets for the FAT and the cluster heap are adjustable, and it says that the rationale for adjusting them is to minimize the number of flash blocks written to. It doesn't say that having the cluster heap start at an alignment boundary will minimize the number of flash blocks written to. That was your assumption. In actuality the number of flash blocks written can be reduced by putting the bitmap and the FAT in the same flash block. That is still "adjusting the offset for the cluster heap," as the text mentions.