### PR TITLE
fsck: add -a option

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -87,6 +87,7 @@ static void usage(char *name)
 	fprintf(stderr, "\t-y | --repair-yes    Repair without ask\n");
 	fprintf(stderr, "\t-n | --repair-no     No repair\n");
 	fprintf(stderr, "\t-p | --repair-auto   Repair automatically\n");
+	fprintf(stderr, "\t-a                   Repair automatically\n");
 	fprintf(stderr, "\t-V | --version       Show version\n");
 	fprintf(stderr, "\t-v | --verbose       Print debug\n");
 	fprintf(stderr, "\t-h | --help          Show help\n");
@@ -1465,7 +1466,7 @@ int main(int argc, char * const argv[])
 		exfat_err("failed to init locale/codeset\n");
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "rynpVvh", opts, NULL)) != EOF) {
+	while ((c = getopt_long(argc, argv, "arynpVvh", opts, NULL)) != EOF) {
 		switch (c) {
 		case 'n':
 			if (ui.options & FSCK_OPTS_REPAIR_ALL)
@@ -1482,6 +1483,7 @@ int main(int argc, char * const argv[])
 				usage(argv[0]);
 			ui.options |= FSCK_OPTS_REPAIR_YES;
 			break;
+		case 'a':
 		case 'p':
 			if (ui.options & FSCK_OPTS_REPAIR_ALL)
 				usage(argv[0]);

--- a/manpages/fsck.exfat.8
+++ b/manpages/fsck.exfat.8
@@ -4,6 +4,8 @@ fsck.exfat \- check an exFAT filesystem
 .SH SYNOPSIS
 .B fsck.exfat
 [
+.B \-a
+] [
 .B \-n
 ] [
 .B \-r
@@ -23,6 +25,9 @@ checks an exFAT filesystem and repairs the filesystem
 depending on the options passed.
 .PP
 .SH OPTIONS
+.TP
+.BI \-a
+This  option  does  the same thing as the -p option.  It is provided for backwards compatibility only;  it  is  suggested  that people use -p option whenever possible.
 .TP
 .BI \-n
 Check the filesystem but do not attempt to repair the filesystem.


### PR DESCRIPTION
This is for backwards compatibility. It does the same as -p.

Signed-off-by: Matthieu CASTET <castet.matthieu@free.fr>