### PR TITLE
exfatprogs: libexfat: make 64-bit compatible set_bit_le()

### DIFF
--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -21,17 +21,17 @@
 #include "version.h"
 
 #ifdef WORDS_BIGENDIAN
-#define BITOP_LE_SWIZZLE	(~0x7)
+#define BITOP_LE_SWIZZLE	((__BITS_PER_LONG - 1) & ~0x7)
 #else
 #define BITOP_LE_SWIZZLE        0
 #endif
 
-#define BIT_MASK(nr)            ((1) << ((nr) % 32))
-#define BIT_WORD(nr)            ((nr) / 32)
+#define BIT_MASK(nr)            (1UL << ((nr) % __BITS_PER_LONG))
+#define BIT_WORD(nr)            ((nr) / __BITS_PER_LONG)
 
 unsigned int print_level  = EXFAT_INFO;
 
-static inline void set_bit(int nr, unsigned int *addr)
+static inline void set_bit(int nr, void *addr)
 {
 	unsigned long mask = BIT_MASK(nr);
 	unsigned long *p = ((unsigned long *)addr) + BIT_WORD(nr);
@@ -39,7 +39,7 @@ static inline void set_bit(int nr, unsigned int *addr)
 	*p  |= mask;
 }
 
-static inline void clear_bit(int nr, unsigned int *addr)
+static inline void clear_bit(int nr, void *addr)
 {
 	unsigned long mask = BIT_MASK(nr);
 	unsigned long *p = ((unsigned long *)addr) + BIT_WORD(nr);


### PR DESCRIPTION
Eric found that bitmap data is not written normally in bitmap location
on s390x(64bit big endian system).
This patch make 64-bit compatible set_bit_le() etc, something like this
does seem to put the bits in the right place in the allocation bitmap at
mkfs time.

Signed-off-by: Eric Sandeen <sandeen@sandeen.net>
Signed-off-by: Namjae Jeon <namjae.jeon@samsung.com>