### PR TITLE
exfatprogs: release 1.1.1 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,19 @@
+exfatprogs 1.1.1 - released 2021-04-21
+======================================
+
+CHANGES :
+ * mkfs.exfat: adjust the boundary alignment calculations to compensate
+   for the volume offset.
+
+NEW FEATURES :
+ * mkfs.exfat: add the "--pack-bitmap" option to relocate the allocation
+   bitmap to allow the FAT and the bitmap to share the same allocation
+   unit on flash media.
+
+BUG FIXES :
+ * Fix wrong bit operations on 64-bit big.
+ * Fix memory leaks in error paths.
+
 exfatprogs 1.1.0 - released 2021-02-09
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.1.0"
+#define EXFAT_PROGS_VERSION "1.1.1"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
exfatprogs 1.1.1 - released 2021-04-21
======================================

CHANGES :
 * mkfs.exfat: adjust the boundary alignment calculations to compensate
   for the volume offset.

NEW FEATURES :
 * mkfs.exfat: add the "--pack-bitmap" option to relocate the allocation
   bitmap to allow the FAT and the bitmap to share the same allocation
   unit on flash media.

BUG FIXES :
 * Fix wrong bit operations on 64-bit big.
 * Fix memory leaks in error paths.

Signed-off-by: Hyunchul Lee <hyc.lee@gmail.com>