### PR TITLE
mkfs: fix boot sector checksum when the sector size is 4 KB

### DIFF
--- a/include/exfat_ondisk.h
+++ b/include/exfat_ondisk.h
@@ -131,17 +131,6 @@ struct pbr {
 	__le16 signature;
 };
 
-/* Extended Boot Sector */
-struct exbs {
-	__u8 zero[510];
-	__le16 signature;
-};
-
-/* Extended Boot Record (8 sectors) */
-struct expbr {
-	struct exbs eb[8];
-};
-
 #define VOLUME_LABEL_MAX_LEN	11
 #define ENTRY_NAME_MAX		15
 

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -559,7 +559,6 @@ static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
 {
 	unsigned int checksum = 0;
 	int ret, sec_idx, backup_sec_idx = 0;
-	int sector_size = bd->sector_size;
 	unsigned char *buf;
 
 	buf = malloc(bd->sector_size);
@@ -581,13 +580,10 @@ static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
 			goto free_buf;
 		}
 
-		if (sec_idx == BOOT_SEC_IDX) {
+		if (sec_idx == BOOT_SEC_IDX)
 			is_boot_sec = true;
-			sector_size = sizeof(struct pbr);
-		} else if (sec_idx >= EXBOOT_SEC_IDX && sec_idx < OEM_SEC_IDX)
-			sector_size = sizeof(struct exbs);
 
-		boot_calc_checksum(buf, sector_size, is_boot_sec,
+		boot_calc_checksum(buf, bd->sector_size, is_boot_sec,
 			&checksum);
 	}
 


### PR DESCRIPTION
"4K native" HDDs advertise a physical sector size and a logical sector
size of 4 KB. A sector size of 4 KB is supported according to the
exFAT specification. From section 3.1.14:

> The valid range of values for [BytesPerSectorShift] shall be:
> * At least 9 (sector size of 512 bytes), which is the smallest
>   sector possible for an exFAT volume
> * At most 12 (sector size of 4096 bytes), which is the memory page
>   size of CPUs common in personal computers

Unfortunately, several bugs in `mkfs.exfat` prevent it from properly
formatting devices whose logical sector size is 4 KB. The Linux kernel
reports the following error at `mount` time:

    $ sudo mount /dev/vda /mnt/
    [  262.063000] exFAT-fs (vda): Invalid boot checksum (boot checksum : 0x8455546b, checksum : 0xfedcaae5)
    [  262.068991] exFAT-fs (vda): invalid boot region
    [  262.071618] exFAT-fs (vda): failed to recognize exfat type
    mount: /mnt: wrong fs type, bad option, bad superblock on /dev/vda, missing codepage or helper program, or other error.

There are 3 issues in `mkfs.exfat:`

1. it truncates some volume structures that should fill an entire
   sector (4 KB for 4Kn HDDs) to 512 bytes when writing them.
2. it computes the main and backup boot checksums using only 512 bytes
   for some sectors. Hence the error reported by Linux.
3. it writes the extended boot signature at offset 510 bytes whatever
   the sector size is.

This is fixed by using `bd->sector_size` to allocate, clear, and
checksum the sectors. Moreover, the extended boot signature is now
placed in the last two bytes of the extended boot sectors.

This patch fixes issue #163.

Signed-off-by: Christophe Vu-Brugier <chritophe.vu-brugier@seagate.com>