### PR TITLE
libexfat: Remove unused parameter in exfat_show_volume_serial

### DIFF
--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -107,8 +107,7 @@ int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
 int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
 		unsigned int checksum, bool is_backup);
 char *exfat_conv_volume_label(struct exfat_dentry *vol_entry);
-int exfat_show_volume_serial(struct exfat_blk_dev *bd,
-		struct exfat_user_input *ui);
+int exfat_show_volume_serial(struct exfat_blk_dev *bd);
 int exfat_set_volume_serial(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui);
 unsigned int exfat_clus_to_blk_dev_off(struct exfat_blk_dev *bd,

--- a/label/label.c
+++ b/label/label.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 	if (serial_mode) {
 		/* Mode to change or display volume serial */
 		if (flags == EXFAT_GET_VOLUME_SERIAL) {
-			ret = exfat_show_volume_serial(&bd, &ui);
+			ret = exfat_show_volume_serial(&bd);
 		} else if (flags == EXFAT_SET_VOLUME_SERIAL) {
 			ui.volume_serial = strtoul(argv[3], NULL, 0);
 			ret = exfat_set_volume_serial(&bd, &ui);

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -528,8 +528,7 @@ free:
 	return ret;
 }
 
-int exfat_show_volume_serial(struct exfat_blk_dev *bd,
-		struct exfat_user_input *ui)
+int exfat_show_volume_serial(struct exfat_blk_dev *bd)
 {
 	struct pbr *ppbr;
 	int ret;

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 
 	/* Mode to change or display volume serial */
 	if (flags == EXFAT_GET_VOLUME_SERIAL) {
-		ret = exfat_show_volume_serial(&bd, &ui);
+		ret = exfat_show_volume_serial(&bd);
 		goto close_fd_out;
 	} else if (flags == EXFAT_SET_VOLUME_SERIAL) {
 		ret = exfat_set_volume_serial(&bd, &ui);


### PR DESCRIPTION
This method won't ever use user input, so it's safe to
assume it'll never be required

As a bonus it fixes Android build

Signed-off-by: Luca Stefani <luca.stefani.ge1@gmail.com>