### PR TITLE
exfat-fixes

### DIFF
--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -43,6 +43,8 @@
 #define EXFAT_GET_VOLUME_SERIAL		0x03
 #define EXFAT_SET_VOLUME_SERIAL		0x04
 
+#define EXFAT_MAX_SECTOR_SIZE		4096
+
 enum {
 	BOOT_SEC_IDX = 0,
 	EXBOOT_SEC_IDX,
@@ -107,7 +109,7 @@ int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
 int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
 		unsigned int checksum, bool is_backup);
 char *exfat_conv_volume_label(struct exfat_dentry *vol_entry);
-int exfat_show_volume_serial(struct exfat_blk_dev *bd);
+int exfat_show_volume_serial(int fd);
 int exfat_set_volume_serial(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui);
 unsigned int exfat_clus_to_blk_dev_off(struct exfat_blk_dev *bd,

--- a/label/label.c
+++ b/label/label.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 	if (serial_mode) {
 		/* Mode to change or display volume serial */
 		if (flags == EXFAT_GET_VOLUME_SERIAL) {
-			ret = exfat_show_volume_serial(&bd);
+			ret = exfat_show_volume_serial(bd.dev_fd);
 		} else if (flags == EXFAT_SET_VOLUME_SERIAL) {
 			ui.volume_serial = strtoul(argv[3], NULL, 0);
 			ret = exfat_set_volume_serial(&bd, &ui);

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -196,7 +196,7 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 	if (ioctl(fd, BLKSSZGET, &bd->sector_size) < 0)
 		bd->sector_size = DEFAULT_SECTOR_SIZE;
 	bd->sector_size_bits = sector_size_bits(bd->sector_size);
-	bd->num_sectors = blk_dev_size / DEFAULT_SECTOR_SIZE;
+	bd->num_sectors = blk_dev_size / bd->sector_size;
 	bd->num_clusters = blk_dev_size / ui->cluster_size;
 
 	exfat_debug("Block device name : %s\n", ui->dev_name);

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
 
 	/* Mode to change or display volume serial */
 	if (flags == EXFAT_GET_VOLUME_SERIAL) {
-		ret = exfat_show_volume_serial(&bd);
+		ret = exfat_show_volume_serial(bd.dev_fd);
 		goto close_fd_out;
 	} else if (flags == EXFAT_SET_VOLUME_SERIAL) {
 		ret = exfat_set_volume_serial(&bd, &ui);


### PR DESCRIPTION
- exfatprogs: tune: use sector size extracted from the boot sector
- exfatprogs: libexfat: fix wrong bd->num_sectors calculation