### PR TITLE
fsck:fix double free of exfat pointer

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1477,6 +1477,11 @@ static char *bytes_to_human_readable(size_t bytes)
 		shift += 10;
 	}
 
+	if(i > =  sizeof(units)/sizeof(units[0])) {
+		i = i - 1;
+		shift = shift - 10;
+	}
+
 	quoti = (unsigned int)(bytes / (1ULL << shift));
 	remain = 0;
 	if (shift > 0) {


### PR DESCRIPTION
in function init_exfat(exfat,bs),if it fails to calloc memory,it will call function free_exfat and return -ENOMEM. Thus it will goto err in main function and call free_exfat(exfat) again.
As follows:
           main
             ->init_exfat(exfat,bs)
               ->free_exfat(exfat)
                 return -ENOMEM
             ->free_exfat(exfat)
let exfat = NULL if we failed to init exfat.

Signed-off-by: yijiangqiu1 <wangfangli@xiaomi.com>