### PR TITLE
fix Out-of-Bounds Accesses in function bytes_to_human_readable

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1477,6 +1477,11 @@ static char *bytes_to_human_readable(size_t bytes)
 		shift += 10;
 	}
 
+	if(i > =  sizeof(units)/sizeof(units[0])) {
+		i = i - 1;
+		shift = shift - 10;
+	}
+
 	quoti = (unsigned int)(bytes / (1ULL << shift));
 	remain = 0;
 	if (shift > 0) {

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1601,9 +1601,10 @@ int main(int argc, char * const argv[])
 		goto err;
 
 	ret = init_exfat(exfat, bs);
-	if (ret)
+	if (ret) {
+		exfat = NULL;
 		goto err;
-
+	}
 	if (exfat_mark_volume_dirty(exfat, true)) {
 		ret = -EIO;
 		goto err;


### PR DESCRIPTION
In function bytes_to_human_readable, if bytes > 1024PB, the variable named i will be 6 and in
“snprintf(buf, sizeof(buf), "%u.%02u %s", quoti, remain, units[i]);”，
function will access units[6] . This will cause Out-of-Bounds Accesses.

Signed-off-by: yijiangqiu1 <wangfangli@xiaomi.com>