### PR TITLE
fsck:fix double free of exfat pointer

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1596,8 +1596,10 @@ int main(int argc, char * const argv[])
 		goto err;
 
 	ret = init_exfat(exfat, bs);
-	if (ret)
+	if (ret) {
+		exfat = NULL;
 		goto err;
+	}
 
 	if (exfat_mark_volume_dirty(exfat, true)) {
 		ret = -EIO;


### PR DESCRIPTION
in function init_exfat(exfat,bs),if it fails to calloc memory,it will call function free_exfat and return -ENOMEM. Thus it will goto err in main function and call free_exfat(exfat) again.
As follows:
           main
             ->init_exfat(exfat,bs)
               ->free_exfat(exfat)
                 return -ENOMEM
             ->free_exfat(exfat)
Let exfat = NULL if we failed to init exfat

Signed-off-by: yijiangqiu1 <wangfangli@xiaomi.com>