### PR TITLE
exfatprogs: release 1.1.3 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,16 @@
+exfatprogs 1.1.3 - released 2021-11-11
+======================================
+
+CHANGES :
+ * mkfs.exfat: ensure that the cluster size is greater than or
+   equal than the sector size.
+ * mkfs.exfat: replace lseek() + write() with pwrite().
+
+BUG FIXES :
+ * mkfs.exfat: prevent an integer overflow when computing the FAT
+   length.
+ * fsck.exfat: fix a double free memory error.
+
 exfatprogs 1.1.2 - released 2021-05-20
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.1.2"
+#define EXFAT_PROGS_VERSION "1.1.3"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
exfatprogs 1.1.3 - released 2021-11-11
======================================

CHANGES :
 * mkfs.exfat: ensure that the cluster size is greater than or
   equal than the sector size.
 * mkfs.exfat: replace lseek() + write() with pwrite().

BUG FIXES :
 * mkfs.exfat: prevent an integer overflow when computing the FAT
   length.
 * fsck.exfat: fix a double free memory error.

Signed-off-by: Hyunchul Lee <hyc.lee@gmail.com>