### PR TITLE
tune: label: fix bitmap entry corruption when adding new volume label

### DIFF
--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -152,50 +152,6 @@ err:
 	return err;
 }
 
-static int read_boot_sect(struct exfat_blk_dev *bdev, struct pbr **bs)
-{
-	struct pbr *pbr;
-	int err = 0;
-	unsigned int sect_size, clu_size;
-
-	pbr = malloc(sizeof(struct pbr));
-
-	if (exfat_read(bdev->dev_fd, pbr, sizeof(*pbr), 0) !=
-	    (ssize_t)sizeof(*pbr)) {
-		exfat_err("failed to read a boot sector\n");
-		err = -EIO;
-		goto err;
-	}
-
-	err = -EINVAL;
-	if (memcmp(pbr->bpb.oem_name, "EXFAT   ", 8) != 0) {
-		exfat_err("failed to find exfat file system\n");
-		goto err;
-	}
-
-	sect_size = 1 << pbr->bsx.sect_size_bits;
-	clu_size = 1 << (pbr->bsx.sect_size_bits +
-			 pbr->bsx.sect_per_clus_bits);
-
-	if (sect_size < 512 || sect_size > 4 * KB) {
-		exfat_err("too small or big sector size: %d\n",
-			  sect_size);
-		goto err;
-	}
-
-	if (clu_size < sect_size || clu_size > 32 * MB) {
-		exfat_err("too small or big cluster size: %d\n",
-			  clu_size);
-		goto err;
-	}
-
-	*bs = pbr;
-	return 0;
-err:
-	free(pbr);
-	return err;
-}
-
 /**
  * @end: excluded.
  */

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -808,45 +808,6 @@ static int read_file(struct exfat_de_iter *de_iter,
 	return ret;
 }
 
-static int read_volume_label(struct exfat *exfat)
-{
-	struct exfat_dentry *dentry;
-	int err;
-	__le16 disk_label[VOLUME_LABEL_MAX_LEN];
-	struct exfat_lookup_filter filter = {
-		.in.type = EXFAT_VOLUME,
-		.in.filter = NULL,
-	};
-
-	err = exfat_lookup_dentry_set(exfat, exfat->root, &filter);
-	if (err)
-		return err;
-
-	dentry = filter.out.dentry_set;
-
-	if (dentry->vol_char_cnt == 0)
-		goto out;
-
-	if (dentry->vol_char_cnt > VOLUME_LABEL_MAX_LEN) {
-		exfat_err("too long label. %d\n", dentry->vol_char_cnt);
-		err = -EINVAL;
-		goto out;
-	}
-
-	memcpy(disk_label, dentry->vol_label, sizeof(disk_label));
-	if (exfat_utf16_dec(disk_label, dentry->vol_char_cnt*2,
-		exfat->volume_label, sizeof(exfat->volume_label)) < 0) {
-		exfat_err("failed to decode volume label\n");
-		err = -EINVAL;
-		goto out;
-	}
-
-	exfat_info("volume label [%s]\n", exfat->volume_label);
-out:
-	free(filter.out.dentry_set);
-	return err;
-}
-
 static int read_bitmap(struct exfat *exfat)
 {
 	struct exfat_lookup_filter filter = {
@@ -1202,7 +1163,7 @@ static int exfat_root_dir_check(struct exfat *exfat)
 	exfat_debug("root directory: start cluster[0x%x] size[0x%" PRIx64 "]\n",
 		root->first_clus, root->size);
 
-	if (read_volume_label(exfat))
+	if (exfat_read_volume_label(exfat))
 		exfat_err("failed to read volume label\n");
 
 	err = read_bitmap(exfat);

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -145,9 +145,8 @@ ssize_t exfat_utf16_enc(const char *in_str, __u16 *out_str, size_t out_size);
 ssize_t exfat_utf16_dec(const __u16 *in_str, size_t in_len,
 			char *out_str, size_t out_size);
 off_t exfat_get_root_entry_offset(struct exfat_blk_dev *bd);
-int exfat_show_volume_label(struct exfat_blk_dev *bd, off_t root_clu_off);
-int exfat_set_volume_label(struct exfat_blk_dev *bd,
-		char *label_input, off_t root_clu_off);
+int exfat_read_volume_label(struct exfat *exfat);
+int exfat_set_volume_label(struct exfat *exfat, char *label_input);
 int exfat_read_sector(struct exfat_blk_dev *bd, void *buf,
 		unsigned int sec_off);
 int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
@@ -169,6 +168,8 @@ off_t exfat_c2o(struct exfat *exfat, unsigned int clus);
 int exfat_o2c(struct exfat *exfat, off_t device_offset,
 	      unsigned int *clu, unsigned int *offset);
 bool exfat_heap_clus(struct exfat *exfat, clus_t clus);
+int exfat_root_clus_count(struct exfat *exfat);
+int read_boot_sect(struct exfat_blk_dev *bdev, struct pbr **bs);
 
 /*
  * Exfat Print

--- a/label/label.c
+++ b/label/label.c
@@ -13,6 +13,7 @@
 
 #include "exfat_ondisk.h"
 #include "libexfat.h"
+#include "exfat_fs.h"
 
 static void usage(void)
 {
@@ -39,7 +40,6 @@ int main(int argc, char *argv[])
 	struct exfat_blk_dev bd;
 	struct exfat_user_input ui;
 	bool version_only = false;
-	off_t root_clu_off;
 	int serial_mode = 0;
 	int flags = 0;
 
@@ -96,15 +96,43 @@ int main(int argc, char *argv[])
 			ret = exfat_set_volume_serial(&bd, &ui);
 		}
 	} else {
-		/* Mode to change or display volume label */
-		root_clu_off = exfat_get_root_entry_offset(&bd);
-		if (root_clu_off < 0)
+		struct exfat *exfat;
+		struct pbr *bs;
+
+		ret = read_boot_sect(&bd, &bs);
+		if (ret)
 			goto close_fd_out;
 
+		exfat = exfat_alloc_exfat(&bd, bs);
+		if (!exfat) {
+			free(bs);
+			ret = -ENOMEM;
+			goto close_fd_out;
+		}
+
+		exfat->root = exfat_alloc_inode(ATTR_SUBDIR);
+		if (!exfat->root) {
+			ret = -ENOMEM;
+			goto free_exfat;
+		}
+
+		exfat->root->first_clus = le32_to_cpu(exfat->bs->bsx.root_cluster);
+		if (exfat_root_clus_count(exfat)) {
+			exfat_err("failed to follow the cluster chain of root\n");
+			exfat_free_inode(exfat->root);
+			ret = -EINVAL;
+			goto free_exfat;
+		}
+
+		/* Mode to change or display volume label */
 		if (flags == EXFAT_GET_VOLUME_LABEL)
-			ret = exfat_show_volume_label(&bd, root_clu_off);
+			ret = exfat_read_volume_label(exfat);
 		else if (flags == EXFAT_SET_VOLUME_LABEL)
-			ret = exfat_set_volume_label(&bd, argv[2], root_clu_off);
+			ret = exfat_set_volume_label(exfat, argv[2]);
+
+free_exfat:
+		if (exfat)
+			exfat_free_exfat(exfat);
 	}
 
 close_fd_out:


### PR DESCRIPTION
When adding new label using tune.exfat or exfatlabel against exfat device formatted by some camera vendor, bitmap entry in root entry is corrupted by overwriting. the format utils of vendor doesn't add volume entry. tune and exfatlabel of exfatprogs assumes that the first entry of the root entry is a volume entry and try overwrite it. This patch lookup and updates the volume entry in the root entry. And adds a new entry to an empty slot if it doesn't exist.

Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>