### PR TITLE
exfatprogs: release 1.2.0 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,26 @@
+exfatprogs 1.2.0 - released 2022-10-28
+======================================
+
+CHANGES :
+ * fsck.exfat: Keep traveling files even if there is a corrupted
+directory entry set.
+ * fsck.exfat: Introduce the option "b" to recover a boot sector even
+if an exFAT filesystem is not found.
+ * fsck.exfat: Introduce the option "s" to create files in
+"/LOST+FOUND", which have clusters allocated but was not belonged to
+any files.
+ * fsck.exfat: Rename '.' and '..' entry name to the one user want.
+
+NEW FEATURES :
+ * fsck.exfat: Repair corruptions of an exFAT filesystem. Please refer
+to fsck.exfat manpage to see what kind of corruptions can be repaired.
+ * exfat2img: Dump metadata of an exFAT filesystem. Please refer to
+exfat2img manpage to see how to use it.
+
+BUG FIXES:
+ * fsck.exfat: Fix an infinite loop while traveling files.
+ * tune.exfat: Fix bitmap entry corruption when adding new volume lablel.
+
 exfatprogs 1.1.3 - released 2021-11-11
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.1.3"
+#define EXFAT_PROGS_VERSION "1.2.0"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
exfatprogs 1.2.0 - released 2022-10-28
======================================

CHANGES :
 * fsck.exfat: Keep traveling files even if there is a corrupted directory entry set.
 * fsck.exfat: Introduce the option "b" to recover a boot sector even if an exFAT filesystem is not found.
 * fsck.exfat: Introduce the option "s" to create files in "/LOST+FOUND", which have clusters allocated but was not belonged to any files.
 * fsck.exfat: Rename '.' and '..' entry name to the one user want.

NEW FEATURES :
 * fsck.exfat: Repair corruptions of an exFAT filesystem. Please refer to fsck.exfat manpage to see what kind of corruptions can be repaired.
 * exfat2img: Dump metadata of an exFAT filesystem. Please refer to exfat2img manpage to see how to use it.

BUG FIXES:
 * fsck.exfat: Fix an infinite loop while traveling files.
 * tune.exfat: Fix bitmap entry corruption when adding new volume lablel.

Signed-off-by: Namjae Jeon <linkinjeon@kernel.org>