### PR TITLE
manpages: fix spelling mistake in fsck.exfat.8

### DIFF
--- a/manpages/fsck.exfat.8
+++ b/manpages/fsck.exfat.8
@@ -42,7 +42,7 @@ Files share the same cluster.  Cluster chains for files except one are broken.
 .IP -
 Start cluster number is invalid. The cluster number and file size are changed to 0.
 .IP -
-Checksum value of direcotry entry set is invalid. Directory entry set is deleted.
+Checksum value of directory entry set is invalid. Directory entry set is deleted.
 .IP -
 Bad hash value of a file name. The hash value is changed properly.
 .IP -


### PR DESCRIPTION
Signed-off-by: Sven Hoexter <sven@stormbind.net>