### PR TITLE
   Fix zero size directory

### DIFF
--- a/fsck/repair.c
+++ b/fsck/repair.c
@@ -61,6 +61,7 @@ static struct exfat_repair_problem problems[] = {
 	{ER_FILE_LARGER_SIZE, ERF_PREEN_YES, ERP_TRUNCATE, 0, 0, 0},
 	{ER_FILE_DUPLICATED_CLUS, ERF_PREEN_YES, ERP_TRUNCATE, 0, 0, 0},
 	{ER_FILE_ZERO_NOFAT, ERF_PREEN_YES, ERP_FIX, 0, 0, 0},
+	{ER_DIR_FIRST_CLUS, ERF_PREEN_YES, ERP_TRUNCATE, 0, 0, 0}
 };
 
 static struct exfat_repair_problem *find_problem(er_problem_code_t prcode)

--- a/fsck/repair.h
+++ b/fsck/repair.h
@@ -23,7 +23,7 @@
 #define ER_FILE_LARGER_SIZE		0x00002005
 #define ER_FILE_DUPLICATED_CLUS		0x00002006
 #define ER_FILE_ZERO_NOFAT		0x00002007
-
+#define ER_DIR_FIRST_CLUS		0x00002008
 typedef unsigned int er_problem_code_t;
 struct exfat_fsck;
 

--- a/include/exfat_dir.h
+++ b/include/exfat_dir.h
@@ -75,6 +75,7 @@ int exfat_update_file_dentry_set(struct exfat *exfat,
 int exfat_build_file_dentry_set(struct exfat *exfat, const char *name,
 				unsigned short attr, struct exfat_dentry **dentry_set,
 				int *dentry_count);
+int find_free_cluster(struct exfat *exfat, clus_t start, clus_t *new_clu);
 int exfat_add_dentry_set(struct exfat *exfat, struct exfat_dentry_loc *loc,
 			 struct exfat_dentry *dset, int dcount,
 			 bool need_next_loc);

--- a/lib/exfat_dir.c
+++ b/lib/exfat_dir.c
@@ -677,7 +677,7 @@ int exfat_update_file_dentry_set(struct exfat *exfat,
 	return 0;
 }
 
-static int find_free_cluster(struct exfat *exfat,
+int find_free_cluster(struct exfat *exfat,
 			     clus_t start, clus_t *new_clu)
 {
 	clus_t end = le32_to_cpu(exfat->bs->bsx.clu_count) +


### PR DESCRIPTION
-  fsck.exfat: Add the ability to fix the directory which size=0 and starts with 0 cluster. This kind of directory often made by Paragon ufsd dirver, and it will cause failure when we try to recognize the directory using linux exfat driver. The way to fix it, we should find a cluster and assign it to the directory's first cluster and modify the size to 1 (Like exfat driver does during mkdir).