### PR TITLE
Exfat2img: Fix void arithmetic error on LLVM

### DIFF
--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -754,7 +754,7 @@ static ssize_t read_stream(int fd, void *buf, size_t len)
 		} else if (ret == 0) {
 			return 0;
 		}
-		buf += (size_t)ret;
+		buf = (char *)buf + (size_t)ret;
 		read_len += (size_t)ret;
 	}
 	return read_len;


### PR DESCRIPTION
When compiling for Android, LLVM or Clang with [-Werror,-Wno-pointer-arith] will cause compilation error. Fix it by casting buf to (char *) before adding length.

GCC uses 1 byte for void pointer arithmetic, which is the same that's used for (char *), so final result is guaranteed to be the same.