### PR TITLE
Fix probles found by OpenScanHub

### DIFF
--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -762,7 +762,7 @@ static ssize_t read_stream(int fd, void *buf, size_t len)
 
 static int restore_from_stdin(struct exfat2img *ei)
 {
-	int in_fd, ret;
+	int in_fd, ret = 0;
 	unsigned char cc;
 	unsigned int clu, end_clu;
 	unsigned int cc_clu_count;

--- a/label/label.c
+++ b/label/label.c
@@ -105,7 +105,6 @@ int main(int argc, char *argv[])
 
 		exfat = exfat_alloc_exfat(&bd, bs);
 		if (!exfat) {
-			free(bs);
 			ret = -ENOMEM;
 			goto close_fd_out;
 		}

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -129,7 +129,6 @@ int main(int argc, char *argv[])
 
 	exfat = exfat_alloc_exfat(&bd, bs);
 	if (!exfat) {
-		free(bs);
 		ret = -ENOMEM;
 		goto close_fd_out;
 	}


### PR DESCRIPTION
Hello,

please see attached patches addressing issues found by redhat's internal tool.

Thank you!

```
Error: UNINIT (CWE-457):
exfatprogs-1.2.2/exfat2img/exfat2img.c:765: var_decl: Declaring variable "ret" without initializer.
exfatprogs-1.2.2/exfat2img/exfat2img.c:895: uninit_use: Using uninitialized value "ret".
#  893|   	fsync(ei->out_fd);
#  894|   	exfat_free_buffer(ei->dump_bdesc, 2);
#  895|-> 	return ret;
#  896|   }
#  897|   

Error: USE_AFTER_FREE (CWE-416):
exfatprogs-1.2.2/label/label.c:106: freed_arg: "exfat_alloc_exfat" frees "bs".
exfatprogs-1.2.2/label/label.c:108: double_free: Calling "free" frees pointer "bs" which has already been freed.
#  106|   		exfat = exfat_alloc_exfat(&bd, bs);
#  107|   		if (!exfat) {
#  108|-> 			free(bs);
#  109|   			ret = -ENOMEM;
#  110|   			goto close_fd_out;

Error: USE_AFTER_FREE (CWE-416):
exfatprogs-1.2.2/tune/tune.c:130: freed_arg: "exfat_alloc_exfat" frees "bs".
exfatprogs-1.2.2/tune/tune.c:132: double_free: Calling "free" frees pointer "bs" which has already been freed.
#  130|   	exfat = exfat_alloc_exfat(&bd, bs);
#  131|   	if (!exfat) {
#  132|-> 		free(bs);
#  133|   		ret = -ENOMEM;
#  134|   		goto close_fd_out;

Error: USE_AFTER_FREE (CWE-416):
exfatprogs-1.2.2/label/label.c:106: freed_arg: "exfat_alloc_exfat" frees "bs".
exfatprogs-1.2.2/label/label.c:108: double_free: Calling "free" frees pointer "bs" which has already been freed.
#  106|   		exfat = exfat_alloc_exfat(&bd, bs);
#  107|   		if (!exfat) {
#  108|-> 			free(bs);
#  109|   			ret = -ENOMEM;
#  110|   			goto close_fd_out;

Error: USE_AFTER_FREE (CWE-416):
exfatprogs-1.2.2/tune/tune.c:130: freed_arg: "exfat_alloc_exfat" frees "bs".
exfatprogs-1.2.2/tune/tune.c:132: double_free: Calling "free" frees pointer "bs" which has already been freed.
#  130|   	exfat = exfat_alloc_exfat(&bd, bs);
#  131|   	if (!exfat) {
#  132|-> 		free(bs);
#  133|   		ret = -ENOMEM;
#  134|   		goto close_fd_out;
```