### PR TITLE
exfatprogs: Fix issues found by OpenScanHub tool

### DIFF
--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -890,7 +890,10 @@ static int restore_from_stdin(struct exfat2img *ei)
 		}
 	}
 out:
-	fsync(ei->out_fd);
+	if (fsync(ei->out_fd)) {
+		exfat_err("failed to fsync: %d\n", errno);
+		ret = -EIO;
+	}
 	exfat_free_buffer(ei->dump_bdesc, 2);
 	return ret;
 }

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1248,7 +1248,6 @@ static int exfat_root_dir_check(struct exfat *exfat)
 	err = exfat_read_volume_label(exfat);
 	if (err && err != EOF)
 		exfat_err("failed to read volume label\n");
-	err = 0;
 
 	err = read_bitmap(exfat);
 	if (err) {

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -981,6 +981,10 @@ int read_boot_sect(struct exfat_blk_dev *bdev, struct pbr **bs)
 	unsigned int sect_size, clu_size;
 
 	pbr = malloc(sizeof(struct pbr));
+	if (!pbr) {
+		exfat_err("failed to allocate memory\n");
+		return -ENOMEM;
+	}
 
 	if (exfat_read(bdev->dev_fd, pbr, sizeof(*pbr), 0) !=
 	    (ssize_t)sizeof(*pbr)) {


### PR DESCRIPTION
Fix some issues found by red hat internal OpenScanHub tool.

exfatprogs-1.2.2/exfat2img/exfat2img.c:893: check_return: Calling
	"fsync" without checking return value (as is done elsewhere
	6 out of 7 times).

exfatprogs-1.2.2/fsck/fsck.c:1251:2: warning[deadcode.DeadStores]:
	Value stored to 'err' is never read

exfatprogs-1.2.2/lib/libexfat.c:983: returned_null: "malloc" returns
	 "NULL" (checked 20 out of 23 times)