### PR TITLE
exfatprogs: Add gitignore and editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.{c,h}]
+indent_style = tab
+indent_size = 8
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+*.o
+*.a
+compile_commands.json
+checkpatch.pl
+.cache
+
+# http://www.gnu.org/software/automake
+
+Makefile.in
+Makefile
+/ar-lib
+/mdate-sh
+/py-compile
+/test-driver
+/ylwrap
+.deps/
+.dirstamp
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+/autoscan.log
+/autoscan-*.log
+/aclocal.m4
+/config.cache
+/config.h.in
+/config.h
+/config.log
+/config.status
+/configure
+/configure.scan
+/stamp-h1
+/build-aux
+
+# https://www.gnu.org/software/libtool/
+
+/libtool
+
+# http://www.gnu.org/software/m4/
+
+/m4
+
+# Binaries
+
+/dump/dump.exfat
+/exfat2img/exfat2img
+/fsck/fsck.exfat
+/label/exfatlabel
+/mkfs/mkfs.exfat
+/tune/tune.exfat


### PR DESCRIPTION
Improves developer experience by preventing build artifacts from being committed by mistake and provides editor indentation configuration.