### PR TITLE
lib: Reset errno before running strtoul in exfat_parse_ulong

### DIFF
--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -1046,6 +1046,8 @@ int exfat_parse_ulong(const char *s, unsigned long *out)
 {
 	char *endptr;
 
+	errno = 0;
+
 	*out = strtoul(s, &endptr, 0);
 
 	if (errno)


### PR DESCRIPTION
Without this the exfat_parse_ulong can fail when errno was set by a different previously called function. This for example happens when calling tune.exfat with C.UTF-8 locale: setlocale sets errno without failing and because of this setting a valid serial number fails:

```
$ sudo LC_ALL=C.UTF-8 tune.exfat -I 0xE67BF34D /dev/loop0 
invalid serial number(0xE67BF34D)
```