### PR TITLE
exfatprogs: release 1.2.4 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+exfatprogs 1.2.4 - released 2024-06-17
+======================================
+
+BUG FIXES :
+ * tune.exfat: Fix "invalid serial number" error when
+   setting an serial number.
+ * fsck.exfat: Fix memory leak in an error path
+
 exfatprogs 1.2.3 - released 2024-05-23
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.2.3"
+#define EXFAT_PROGS_VERSION "1.2.4"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
BUG FIXES :
 * tune.exfat: Fix "invalid serial number" error when setting an serial number.
 * fsck.exfat: Fix memory leak in an error path