### PR TITLE
exfatprogs: remove the limitation that the device path length cannot exceed 254 bytes

### DIFF
--- a/dump/dump.c
+++ b/dump/dump.c
@@ -247,8 +247,7 @@ int main(int argc, char *argv[])
 	if (argc < 2)
 		usage();
 
-	memset(ui.dev_name, 0, sizeof(ui.dev_name));
-	snprintf(ui.dev_name, sizeof(ui.dev_name), "%s", argv[1]);
+	ui.dev_name = argv[1];
 
 	ret = exfat_get_blk_dev_info(&ui, &bd);
 	if (ret < 0)

--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -926,7 +926,7 @@ int main(int argc, char * const argv[])
 	}
 
 	memset(&ui, 0, sizeof(ui));
-	snprintf(ui.dev_name, sizeof(ui.dev_name), "%s", blkdev_path);
+	ui.dev_name = blkdev_path;
 	if (restore)
 		ui.writeable = true;
 	else

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1616,7 +1616,7 @@ int main(int argc, char * const argv[])
 
 	exfat_fsck.options = ui.options;
 
-	snprintf(ui.ei.dev_name, sizeof(ui.ei.dev_name), "%s", argv[optind]);
+	ui.ei.dev_name = argv[optind];
 	ret = exfat_get_blk_dev_info(&ui.ei, &bd);
 	if (ret < 0) {
 		exfat_err("failed to open %s. %d\n", ui.ei.dev_name, ret);

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -78,7 +78,7 @@ struct exfat_blk_dev {
 };
 
 struct exfat_user_input {
-	char dev_name[255];
+	const char *dev_name;
 	bool writeable;
 	unsigned int sector_size;
 	unsigned int cluster_size;

--- a/label/label.c
+++ b/label/label.c
@@ -81,8 +81,7 @@ int main(int argc, char *argv[])
 	if (argc < 2)
 		usage();
 
-	memset(ui.dev_name, 0, sizeof(ui.dev_name));
-	snprintf(ui.dev_name, sizeof(ui.dev_name), "%s", argv[serial_mode + 1]);
+	ui.dev_name = argv[serial_mode + 1];
 
 	ret = exfat_get_blk_dev_info(&ui, &bd);
 	if (ret < 0)

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -737,8 +737,7 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	memset(ui.dev_name, 0, sizeof(ui.dev_name));
-	snprintf(ui.dev_name, sizeof(ui.dev_name), "%s", argv[optind]);
+	ui.dev_name = argv[optind];
 
 	ret = exfat_get_blk_dev_info(&ui, &bd);
 	if (ret < 0)

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -118,8 +118,7 @@ int main(int argc, char *argv[])
 	if (argc < 3)
 		usage();
 
-	memset(ui.dev_name, 0, sizeof(ui.dev_name));
-	snprintf(ui.dev_name, sizeof(ui.dev_name), "%s", argv[argc - 1]);
+	ui.dev_name = argv[argc - 1];
 
 	ret = exfat_get_blk_dev_info(&ui, &bd);
 	if (ret < 0)


### PR DESCRIPTION

Since the copy of the device path in exfat_user_input is only 255 bytes, if the device path length is greater than 254, these tools will not work. To remove this limitation, use the user input device path directly instead of a copy in exfat_user_input.

```
fstest@fstest:~/exfatprogs$ dir=/tmp/`shuf -zer -n255  {A..Z} {a..z} {0..9} | tr -d "\0"`
fstest@fstest:~/exfatprogs$ mkdir -v $dir
mkdir: created directory '/tmp/B9aI8Bv0hGEmSN2S5WLJElmyUPzftavJ3UWx8erzPnMtNAe8iMy1Oi3RvT7MqXKZT2h4pCQfBGLRvTQppsK4R1ADbSq48Ok3RQgvT1iNRWh9c6aLrs1YYl0ZhPDsqtvvTxWFJikXKc2vJquNfpQ8OsIcfR311zr5KsiFHI3UUZGyzXexr5zZ3vsxuuY9AeTrWi4MdX4kdaaIOxPemH6MShUM9RoigwwMtzk9nwIaOnlV2k1G81Zs96EllYUdiNQ'
fstest@fstest:~/exfatprogs$ truncate -s 16M $dir/exfat.img
fstest@fstest:~/exfatprogs$ mkfs.exfat $dir/exfat.img
exfatprogs version : 1.2.4
open failed : /tmp/B9aI8Bv0hGEmSN2S5WLJElmyUPzftavJ3UWx8erzPnMtNAe8iMy1Oi3RvT7MqXKZT2h4pCQfBGLRvTQppsK4R1ADbSq48Ok3RQgvT1iNRWh9c6aLrs1YYl0ZhPDsqtvvTxWFJikXKc2vJquNfpQ8OsIcfR311zr5KsiFHI3UUZGyzXexr5zZ3vsxuuY9AeTrWi4MdX4kdaaIOxPemH6MShUM9RoigwwMtzk9nwIaOnlV2k1G81Zs96Ell, No such file or directory

exFAT format fail!
fstest@fstest:~/exfatprogs$ ./mkfs/mkfs.exfat $dir/exfat.img
exfatprogs version : 1.2.4
Creating exFAT filesystem(/tmp/B9aI8Bv0hGEmSN2S5WLJElmyUPzftavJ3UWx8erzPnMtNAe8iMy1Oi3RvT7MqXKZT2h4pCQfBGLRvTQppsK4R1ADbSq48Ok3RQgvT1iNRWh9c6aLrs1YYl0ZhPDsqtvvTxWFJikXKc2vJquNfpQ8OsIcfR311zr5KsiFHI3UUZGyzXexr5zZ3vsxuuY9AeTrWi4MdX4kdaaIOxPemH6MShUM9RoigwwMtzk9nwIaOnlV2k1G81Zs96EllYUdiNQ/exfat.img, cluster size=4096)

Writing volume boot record: done
Writing backup volume boot record: done
Fat table creation: done
Allocation bitmap creation: done
Upcase table creation: done
Writing root directory entry: done
Synchronizing...

exFAT format complete!
```