### PR TITLE
Update checkout action

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: before test
       run: |
         sudo apt-get install linux-headers-$(uname -r)


### PR DESCRIPTION
github ci: update checkout action to v4
    
The v3 release of the checkout action relies on node16 which is deprecated, thus switch to the current major version which moved on to node20.

Signed-off-by: Sven Hoexter <sven@stormbind.net>