### PR TITLE
ci: invoke apt only once

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,8 +19,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: before test
       run: |
-        sudo apt-get install linux-headers-$(uname -r)
-        sudo apt-get install xz-utils
+        sudo apt-get install linux-headers-$(uname -r) xz-utils
         git clone https://github.com/namjaejeon/linux-exfat-oot
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
         export PATH=/usr/local/lib:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ notifications:
  - email: true
 
 before_script:
- - sudo apt-get install linux-headers-$(uname -r)
- - sudo apt-get install xz-utils
+ - sudo apt-get install linux-headers-$(uname -r) xz-utils
  - git clone --branch=exfat-next https://github.com/namjaejeon/exfat_oot
  - ./.travis_get_mainline_kernel
  - export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
Apt has to read a bunch of data each time it's invoked, to avoid that just run it once and install all required packages.