### PR TITLE
lib: prefer the physical block size over the logical block size

### DIFF
--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -189,6 +189,8 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 
 	if (ui->sector_size)
 		bd->sector_size = ui->sector_size;
+	else if (ioctl(fd, BLKPBSZGET, &bd->sector_size) >= 0)
+		;
 	else if (ioctl(fd, BLKSSZGET, &bd->sector_size) < 0)
 		bd->sector_size = DEFAULT_SECTOR_SIZE;
 	bd->sector_size_bits = sector_size_bits(bd->sector_size);


### PR DESCRIPTION
The physical block size is the smallest unit a physical storage device can write atomically. Preferring it over the logical block size should typically improve performance on drives with a 4096 byte physical sector size and a 512 byte logical sector size, e.g. 512e Advanced Format HDDs and some rare SATA SSDs.

Closes: https://github.com/exfatprogs/exfatprogs/issues/277