### PR TITLE
exfatprogs: fix argument validation check (2)

### DIFF
--- a/label/label.c
+++ b/label/label.c
@@ -78,7 +78,8 @@ int main(int argc, char *argv[])
 	if (version_only)
 		exit(EXIT_FAILURE);
 
-	if (argc - optind != 1)
+	if (argc - optind != 1 && flags != EXFAT_SET_VOLUME_LABEL &&
+			flags != EXFAT_SET_VOLUME_SERIAL)
 		usage();
 
 	ui.dev_name = argv[serial_mode + 1];


### PR DESCRIPTION
Since commit 7d354e5be83ed3bb981c59b3435ff64da56d185d ("exfatprogs: fix argument validation check"), exfatlabel tool error out when we try to set a new volume serial or label.

  exfatlabel /dev/sda1 "new label"
  exfatlabel -i /dev/sda1 0x12345678

Error out only if too few argument is given, ignore additional arguments.

Fixes:
https://gitlab.com/buildroot.org/buildroot/-/jobs/8199992419