### PR TITLE
Extend mkfs.exfat.8 man page with notes about the volume GUID

### DIFF
--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -111,6 +111,10 @@ Specifies the volume label to be associated with the exFAT filesystem.
 .TP
 .BR \-U ", " \-\-volume\-guid =\fIguid\fR
 Specifies the volume GUID to be associated with the exFAT filesystem.
+It can be given in the standard, hypenized UUID format like
+\fBaaaabbbb-cccc-dddd-eeee-ffff00001111\fR. Note: The volume GUID cannot be used
+to set the the 8-letter ID reported by \fIblkid\fR or used as
+the filesystem UUID in \fB/etc/fstab\fR.
 .TP
 .B \-\-pack\-bitmap
 Attempts to relocate the exFAT allocation bitmap so that it ends at the


### PR DESCRIPTION
Closes #275.

The behavior of blkid was determined via experiments: Re-creating an exFAT filesystem twice using the same GUID resulted in two different values reported for the UUID by blkid.