### PR TITLE
mkfs: fix orphan clusters

### DIFF
--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -303,7 +303,7 @@ static int exfat_create_fat_table(struct exfat_blk_dev *bd,
 	if (clu < 0)
 		return ret;
 
-	finfo.used_clu_cnt = clu + 1;
+	finfo.used_clu_cnt = clu + 1 - EXFAT_FIRST_CLUSTER;
 	exfat_debug("Total used cluster count : %d\n", finfo.used_clu_cnt);
 
 	return ret;


### PR DESCRIPTION
Due to incorrect calculation of the number of used clusters, there are two orphan clusters in the newly created file system.

`LOST+FOUND/FILE0000000.CHK` was created after running `fsck.exfat -s -y`.
```
fstest@fstest:~/exfatprogs$ mkfs.exfat exfat.img 
exfatprogs version : 1.2.5
Creating exFAT filesystem(exfat.img, cluster size=4096)

Writing volume boot record: done
Writing backup volume boot record: done
Fat table creation: done
Allocation bitmap creation: done
Upcase table creation: done
Writing root directory entry: done
Synchronizing...

exFAT format complete!
fstest@fstest:~/exfatprogs$ sudo mount exfat.img /mnt/test/
fstest@fstest:~/exfatprogs$ find /mnt/test/
/mnt/test/
fstest@fstest:~/exfatprogs$ sudo umount /mnt/test 
fstest@fstest:~/exfatprogs$ fsck.exfat -s -y exfat.img 
exfatprogs version : 1.2.5
exfat.img: clean. directories 1, files 0
fstest@fstest:~/exfatprogs$ sudo mount exfat.img /mnt/test/
fstest@fstest:~/exfatprogs$ find /mnt/test/
/mnt/test/
/mnt/test/LOST+FOUND
/mnt/test/LOST+FOUND/FILE0000000.CHK
```