### PR TITLE
Merge patches in exfat-next branch to master for 1.2.6 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,20 @@
+exfatprogs 1.2.6 - released 2024-11-20
+======================================
+
+CHANGES :
+ * exfatprogs: replace obsolete autoconf and libtool
+   macros.
+ * mkfs.exfat: prefer the physical block size over
+   the logical block size for the exFAT sector size.
+ * mkfs.exfat: add notes about the format of the volume
+   GUID to the man page.
+ * mkfs.exfat: fix an incorrect calculation of the number
+   of used clusters.
+
+BUG FIXES :
+ * exfatlabel: fix an user input error when setting
+   a volume serial or label.
+
 exfatprogs 1.2.5 - released 2024-08-06
 ======================================
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.68])
+AC_PREREQ([2.70])
 
 m4_define([exfat_progs_version], m4_esyscmd_s(
 	 grep "define EXFAT_PROGS_VERSION " include/version.h | \
@@ -11,16 +11,15 @@ AC_INIT([exfatprogs],
 	[https://github.com/exfatprogs/exfatprogs])
 
 AC_CONFIG_SRCDIR([config.h.in])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([foreign tar-pax dist-xz subdir-objects])
 
 AC_LANG([C])
 AC_PROG_CC
-AC_PROG_CC_STDC
 AM_SILENT_RULES([yes])
-AC_PROG_LIBTOOL
+LT_INIT
 AC_SYS_LARGEFILE
 AC_C_BIGENDIAN
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.2.5"
+#define EXFAT_PROGS_VERSION "1.2.6"
 
 #endif /* !_VERSION_H */

--- a/label/label.c
+++ b/label/label.c
@@ -78,7 +78,8 @@ int main(int argc, char *argv[])
 	if (version_only)
 		exit(EXIT_FAILURE);
 
-	if (argc - optind != 1)
+	if (argc - optind != 1 && flags != EXFAT_SET_VOLUME_LABEL &&
+	    flags != EXFAT_SET_VOLUME_SERIAL)
 		usage();
 
 	ui.dev_name = argv[serial_mode + 1];

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -189,6 +189,8 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 
 	if (ui->sector_size)
 		bd->sector_size = ui->sector_size;
+	else if (ioctl(fd, BLKPBSZGET, &bd->sector_size) >= 0)
+		;
 	else if (ioctl(fd, BLKSSZGET, &bd->sector_size) < 0)
 		bd->sector_size = DEFAULT_SECTOR_SIZE;
 	bd->sector_size_bits = sector_size_bits(bd->sector_size);

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -111,6 +111,10 @@ Specifies the volume label to be associated with the exFAT filesystem.
 .TP
 .BR \-U ", " \-\-volume\-guid =\fIguid\fR
 Specifies the volume GUID to be associated with the exFAT filesystem.
+It can be given in the standard, hypenized UUID format like
+\fBaaaabbbb-cccc-dddd-eeee-ffff00001111\fR. Note: The volume GUID cannot be used
+to set the the 8-letter ID reported by \fIblkid\fR or used as
+the filesystem UUID in \fB/etc/fstab\fR.
 .TP
 .B \-\-pack\-bitmap
 Attempts to relocate the exFAT allocation bitmap so that it ends at the

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -303,7 +303,7 @@ static int exfat_create_fat_table(struct exfat_blk_dev *bd,
 	if (clu < 0)
 		return ret;
 
-	finfo.used_clu_cnt = clu + 1;
+	finfo.used_clu_cnt = clu + 1 - EXFAT_FIRST_CLUSTER;
 	exfat_debug("Total used cluster count : %d\n", finfo.used_clu_cnt);
 
 	return ret;


### PR DESCRIPTION
Merge patches in exfat-next branch to master for 1.2.6 release

CHANGES :
    * exfatprogs: replace obsolete autoconf and libtool
       macros.
    * mkfs.exfat: prefer the physical block size over
       the logical block size for the exFAT sector size.
    * mkfs.exfat: add notes about the format of the volume
       GUID to the man page.
    * mkfs.exfat: fix an incorrect calculation of the number
       of used clusters.
    
BUG FIXES :
    * exfatlabel: fix an user input error when setting
       a volume serial or label.
