### PR TITLE
manpages: make sure to load the tbl preprocessor for the mkfs page

### DIFF
--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -1,3 +1,4 @@
+'\" t
 .TH mkfs.exfat 8
 .SH NAME
 mkfs.exfat \- create an exFAT filesystem


### PR DESCRIPTION
The manpage for mkfs makes use of the tbl(1) groff preprocessor but does not ensure that it's loaded by man to its filter pipeline.

According to man(1):

    To contain a valid preprocessor string, the first line must resemble
    '\" <string>
     where string can be any combination of letters described by option -p below.

There `t` is listed for the tbl preprocessor.

The Debian linting tool lintian started to raise awareness for this kind of issue. One can reproduce the testing condition used by lintian locally by invoking the manpage via

    LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 man --warnings -E UTF-8 -l -Tutf8 -Z mkfs.exfat.8 >/dev/null

Here the `MANROFFSEQ` environment variable is explicitly kept empty to figure out if a preprocessor is missing.