### PR TITLE
fix dumping of volume-label/bitmap/upcase entries

### DIFF
--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -108,13 +108,11 @@ static void free_exfat2img(struct exfat2img *ei)
 		close(ei->bdev.dev_fd);
 }
 
-static int create_exfat2img(struct exfat2img *ei,
-			    struct pbr *bs,
-			    const char *out_path)
+static int create_exfat2img(struct exfat2img *ei, const char *out_path)
 {
 	int err;
 
-	ei->exfat = exfat_alloc_exfat(&ei->bdev, bs);
+	ei->exfat = exfat_alloc_exfat(&ei->bdev, NULL);
 	if (!ei->exfat)
 		return -ENOMEM;
 
@@ -884,7 +882,6 @@ int main(int argc, char * const argv[])
 {
 	int err = 0, c;
 	const char *in_path, *out_path = NULL, *blkdev_path;
-	struct pbr *bs;
 	struct exfat_user_input ui;
 	off_t last_sect;
 	bool restore;
@@ -940,13 +937,7 @@ int main(int argc, char * const argv[])
 	if (restore)
 		return restore_from_stdin(&ei);
 
-	err = read_boot_sect(&ei.bdev, &bs);
-	if (err) {
-		close(ei.bdev.dev_fd);
-		return EXIT_FAILURE;
-	}
-
-	err = create_exfat2img(&ei, bs, out_path);
+	err = create_exfat2img(&ei, out_path);
 	if (err)
 		return EXIT_FAILURE;
 

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1325,8 +1325,6 @@ static int exfat_root_dir_check(struct exfat *exfat)
 	root->first_clus = le32_to_cpu(exfat->bs->bsx.root_cluster);
 	if (root_check_clus_chain(exfat, root, &clus_count)) {
 		exfat_err("failed to follow the cluster chain of root\n");
-		exfat_free_inode(root);
-		exfat->root = NULL;
 		return -EINVAL;
 	}
 	root->size = clus_count * exfat->clus_size;
@@ -1352,13 +1350,8 @@ static int exfat_root_dir_check(struct exfat *exfat)
 	}
 
 	root->dev_offset = 0;
-	err = exfat_build_file_dentry_set(exfat, " ", ATTR_SUBDIR,
+	return exfat_build_file_dentry_set(exfat, " ", ATTR_SUBDIR,
 					  &root->dentry_set, &root->dentry_count);
-	if (err) {
-		exfat_free_inode(root);
-		return -ENOMEM;
-	}
-	return 0;
 }
 
 static int read_lostfound(struct exfat *exfat, struct exfat_inode **lostfound)

--- a/include/exfat_fs.h
+++ b/include/exfat_fs.h
@@ -68,7 +68,8 @@ struct buffer_desc {
 	char		dirty[EXFAT_BITMAP_SIZE(4 * KB / 512)];
 };
 
-struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs);
+struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs,
+                                struct exfat_inode *root);
 void exfat_free_exfat(struct exfat *exfat);
 
 struct exfat_inode *exfat_alloc_inode(__u16 attr);

--- a/label/label.c
+++ b/label/label.c
@@ -109,23 +109,10 @@ int main(int argc, char *argv[])
 	} else {
 		struct exfat *exfat;
 
-		exfat = exfat_alloc_exfat(&bd, NULL);
+		exfat = exfat_alloc_exfat(&bd, NULL, NULL);
 		if (!exfat) {
 			ret = -ENOMEM;
 			goto close_fd_out;
-		}
-
-		exfat->root = exfat_alloc_inode(ATTR_SUBDIR);
-		if (!exfat->root) {
-			ret = -ENOMEM;
-			goto free_exfat;
-		}
-
-		exfat->root->first_clus = le32_to_cpu(exfat->bs->bsx.root_cluster);
-		if (exfat_root_clus_count(exfat)) {
-			exfat_err("failed to follow the cluster chain of root\n");
-			ret = -EINVAL;
-			goto free_exfat;
 		}
 
 		/* Mode to change or display volume label */
@@ -134,9 +121,7 @@ int main(int argc, char *argv[])
 		else if (flags == EXFAT_SET_VOLUME_LABEL)
 			ret = exfat_set_volume_label(exfat, argv[2]);
 
-free_exfat:
-		if (exfat)
-			exfat_free_exfat(exfat);
+		exfat_free_exfat(exfat);
 	}
 
 close_fd_out:

--- a/label/label.c
+++ b/label/label.c
@@ -129,7 +129,6 @@ int main(int argc, char *argv[])
 		exfat->root->first_clus = le32_to_cpu(exfat->bs->bsx.root_cluster);
 		if (exfat_root_clus_count(exfat)) {
 			exfat_err("failed to follow the cluster chain of root\n");
-			exfat_free_inode(exfat->root);
 			ret = -EINVAL;
 			goto free_exfat;
 		}

--- a/label/label.c
+++ b/label/label.c
@@ -108,13 +108,8 @@ int main(int argc, char *argv[])
 		}
 	} else {
 		struct exfat *exfat;
-		struct pbr *bs;
 
-		ret = read_boot_sect(&bd, &bs);
-		if (ret)
-			goto close_fd_out;
-
-		exfat = exfat_alloc_exfat(&bd, bs);
+		exfat = exfat_alloc_exfat(&bd, NULL);
 		if (!exfat) {
 			ret = -ENOMEM;
 			goto close_fd_out;

--- a/lib/exfat_fs.c
+++ b/lib/exfat_fs.c
@@ -127,6 +127,11 @@ struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs)
 {
 	struct exfat *exfat;
 
+	if (!bs) {
+		if (read_boot_sect(blk_dev, &bs))
+			return NULL;
+	}
+
 	exfat = calloc(1, sizeof(*exfat));
 	if (!exfat) {
 		free(bs);

--- a/lib/exfat_fs.c
+++ b/lib/exfat_fs.c
@@ -123,7 +123,8 @@ void exfat_free_exfat(struct exfat *exfat)
 	}
 }
 
-struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs)
+struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs,
+		struct exfat_inode *root)
 {
 	struct exfat *exfat;
 
@@ -134,6 +135,9 @@ struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs)
 
 	exfat = calloc(1, sizeof(*exfat));
 	if (!exfat) {
+		if (root)
+			exfat_free_inode(root);
+
 		free(bs);
 		return NULL;
 	}
@@ -144,6 +148,7 @@ struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs)
 	exfat->clus_count = le32_to_cpu(bs->bsx.clu_count);
 	exfat->clus_size = EXFAT_CLUSTER_SIZE(bs);
 	exfat->sect_size = EXFAT_SECTOR_SIZE(bs);
+	exfat->root = root;
 
 	/* TODO: bitmap could be very large. */
 	exfat->alloc_bitmap = calloc(1, EXFAT_BITMAP_SIZE(exfat->clus_count));
@@ -168,6 +173,21 @@ struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs)
 		exfat_get_read_size(exfat) + 1;
 
 	exfat->start_clu = EXFAT_FIRST_CLUSTER;
+
+	if (exfat->root)
+		return exfat;
+
+	exfat->root = exfat_alloc_inode(ATTR_SUBDIR);
+	if (!exfat->root)
+		goto err;
+
+	exfat->root->first_clus = le32_to_cpu(exfat->bs->bsx.root_cluster);
+
+	if (exfat_root_clus_count(exfat)) {
+		exfat_err("failed to follow the cluster chain of root\n");
+		goto err;
+	}
+
 	return exfat;
 err:
 	exfat_free_exfat(exfat);

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -152,7 +152,6 @@ int main(int argc, char *argv[])
 	exfat->root->first_clus = le32_to_cpu(exfat->bs->bsx.root_cluster);
 	if (exfat_root_clus_count(exfat)) {
 		exfat_err("failed to follow the cluster chain of root\n");
-		exfat_free_inode(exfat->root);
 		ret = -EINVAL;
 		goto close_fd_out;
 	}

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -56,7 +56,6 @@ int main(int argc, char *argv[])
 	int flags = 0;
 	char label_input[VOLUME_LABEL_BUFFER_SIZE];
 	struct exfat *exfat = NULL;
-	struct pbr *bs;
 
 	init_user_input(&ui);
 
@@ -133,11 +132,7 @@ int main(int argc, char *argv[])
 		goto close_fd_out;
 	}
 
-	ret = read_boot_sect(&bd, &bs);
-	if (ret)
-		goto close_fd_out;
-
-	exfat = exfat_alloc_exfat(&bd, bs);
+	exfat = exfat_alloc_exfat(&bd, NULL);
 	if (!exfat) {
 		ret = -ENOMEM;
 		goto close_fd_out;

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -132,22 +132,9 @@ int main(int argc, char *argv[])
 		goto close_fd_out;
 	}
 
-	exfat = exfat_alloc_exfat(&bd, NULL);
+	exfat = exfat_alloc_exfat(&bd, NULL, NULL);
 	if (!exfat) {
 		ret = -ENOMEM;
-		goto close_fd_out;
-	}
-
-	exfat->root = exfat_alloc_inode(ATTR_SUBDIR);
-	if (!exfat->root) {
-		ret = -ENOMEM;
-		goto close_fd_out;
-	}
-
-	exfat->root->first_clus = le32_to_cpu(exfat->bs->bsx.root_cluster);
-	if (exfat_root_clus_count(exfat)) {
-		exfat_err("failed to follow the cluster chain of root\n");
-		ret = -EINVAL;
 		goto close_fd_out;
 	}
 


### PR DESCRIPTION
This PR is to fix dump.exfat displaying wrong information.

During the development process, I found some codes that needs to be fixed or can be optimized, which are also included in this PR.