### PR TITLE
exfatprogs: release 1.2.7 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,19 @@
+exfatprogs 1.2.7 - released 2025-02-03
+======================================
+
+NEW FEATURES :
+ * fsck.exfat: support repairing the upcase table.
+
+CHANGES :
+ * exfatprogs: make sure to load the tbl preprocessor
+   for man pages.
+
+BUG FIXES :
+ * exfatprogs: fix a double free memory error.
+ * dump.exfat: fix a constraint that volume label, bitmap,
+   upcase table must be located at the beginning of a root
+   directory.
+
 exfatprogs 1.2.6 - released 2024-11-20
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.2.6"
+#define EXFAT_PROGS_VERSION "1.2.7"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
exfatprogs 1.2.7 - released 2025-02-03
======================================

NEW FEATURES :
 * fsck.exfat: support repairing the upcase table.

CHANGES :
 * exfatprogs: make sure to load the tbl preprocessor for man pages.

BUG FIXES :
 * exfatprogs: fix a double free memory error.
 * dump.exfat: fix a constraint that volume label, bitmap, upcase table must be located at the beginning of a root directory.