### PR TITLE
exfatprogs: release 1.2.8 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+exfatprogs 1.2.8 - released 2025-02-14
+======================================
+
+BUG FIXES :
+ * dump.exfat: fix an incorrect output of an entry
+   position in 32-bit system.
+
 exfatprogs 1.2.7 - released 2025-02-03
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.2.7"
+#define EXFAT_PROGS_VERSION "1.2.8"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
exfatprogs 1.2.8 - released 2025-02-14
======================================

BUG FIXES :
 * dump.exfat: fix an incorrect output of an entry position in 32-bit system.

Signe-off-by: Hyunchul Lee <hyc.lee@gmail.com>