### PR TITLE
fix: debug output when clearing disk

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+exfatprogs 1.2.8 - released 2025-02-14
+======================================
+
+BUG FIXES :
+ * dump.exfat: fix an incorrect output of an entry
+   position in 32-bit system.
+
 exfatprogs 1.2.7 - released 2025-02-03
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.2.7"
+#define EXFAT_PROGS_VERSION "1.2.8"
 
 #endif /* !_VERSION_H */

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -528,7 +528,6 @@ static int exfat_zero_out_disk(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
 	int ret;
-	unsigned long long total_written = 0;
 	unsigned long long size;
 
 	if (ui->quick)
@@ -543,7 +542,7 @@ static int exfat_zero_out_disk(struct exfat_blk_dev *bd,
 	}
 
 	exfat_debug("zero out written size : %llu, disk size : %llu\n",
-		total_written, bd->size);
+		size, bd->size);
 	return 0;
 }
 


### PR DESCRIPTION
Currently the debug output when calling `exfat_zero_out_disk` states that zero bytes were written, regardless of the actual amount of bytes written. With this small fix the appropriate number is printed instead.