### PR TITLE
ci: Run Build and fsck Tests in Alpine Container to Cover musl

### DIFF
--- a/.github/workflows/buildtest-alpine.yml
+++ b/.github/workflows/buildtest-alpine.yml
@@ -1,0 +1,31 @@
+name: Container Buildtest Alpine
+
+on:
+  push:
+    branches:
+      - master
+      - exfat-next
+  pull_request:
+    branches:
+      - master
+      - exfat-next
+
+jobs:
+  container-build-alpine:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Packages
+        run: apk --update add alpine-sdk autoconf libtool automake linux-headers bash xxd xz
+      - name: Autoconf and Configure
+        run: ./autogen.sh && ./configure
+      - name: Build
+        run: make -j$((`nproc`+1))
+      - name: Install
+        run: make install
+      - name: run fsck repair testcases
+        run: |
+          cd tests
+          ./test_fsck.sh

--- a/tests/test_fsck.sh
+++ b/tests/test_fsck.sh
@@ -19,7 +19,7 @@ cleanup() {
 }
 
 if [ $# -eq 0 ]; then
-	TESTCASE_LIST=($(find . -name "${IMAGE_FILE}.tar.xz" | xargs dirname))
+	TESTCASE_LIST=($(find . -name "${IMAGE_FILE}.tar.xz" -exec dirname {} \;))
 	TESTCASE_LIST+=($(find . -name "[[:digit:]]*.sh" | sort))
 else
 	TESTCASE_LIST=($@)


### PR DESCRIPTION
Utilizes the GitHub actions native way of executing build steps in a container. Here we run in the alpine:latest container image to validate exfatprogs builds on the musl libc implementation.