### PR TITLE
ci: Add Build Test with Debian + clang + lld

### DIFF
--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -1,4 +1,4 @@
-name: Container Buildtest Alpine
+name: Container Buildtests
 
 on:
   push:
@@ -23,6 +23,26 @@ jobs:
         run: ./autogen.sh && ./configure
       - name: Build
         run: make -j$((`nproc`+1))
+      - name: Install
+        run: make install
+      - name: run fsck repair testcases
+        run: |
+          cd tests
+          ./test_fsck.sh
+  container-build-clang-lld:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:unstable
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Packages
+        run: apt update && apt -y install clang lld pkgconf xxd autoconf libtool automake make xz-utils
+      - name: Autoconf and Configure
+        run: |
+          export LDFLAGS="-fuse-ld=lld"
+          ./autogen.sh && ./configure
+      - name: Build
+        run:  make -j$((`nproc`+1))
       - name: Install
         run: make install
       - name: run fsck repair testcases


### PR DESCRIPTION
Extends the container based build tests by a second one which builds exfatprogs on Debian (libc based) with clang and linking done by lld. Only tests we run so far are the fsck tests.


@namjaejeon I'm not sure if that additional build test offers enough value right now to justify the additional build minutes it requires to run.