### PR TITLE
Support dumping directory entry

### DIFF
--- a/dump/dump.c
+++ b/dump/dump.c
@@ -24,6 +24,8 @@
 
 #define dump_field(name, fmt, ...)	\
 	exfat_info("%-40s " fmt "\n", name ":", ##__VA_ARGS__)
+#define dump_dentry_field(name, fmt, ...)	\
+	exfat_info("   %-30s  " fmt "\n", name ":", ##__VA_ARGS__)
 
 static const unsigned char used_bit[] = {
 	0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3,/*  0 ~  19*/
@@ -44,6 +46,7 @@ static const unsigned char used_bit[] = {
 static void usage(void)
 {
 	fprintf(stderr, "Usage: dump.exfat\n");
+	fprintf(stderr, "\t-d | --dentry-set=path                Show directory entry set\n");
 	fprintf(stderr, "\t-V | --version                        Show version\n");
 	fprintf(stderr, "\t-h | --help                           Show help\n");
 
@@ -51,6 +54,7 @@ static void usage(void)
 }
 
 static struct option opts[] = {
+	{"dentry-set",		required_argument,	NULL,	'd' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"help",		no_argument,		NULL,	'h' },
 	{"?",			no_argument,		NULL,	'?' },
@@ -222,6 +226,363 @@ static int exfat_show_fs_info(struct exfat *exfat)
 	return 0;
 }
 
+/*
+ * Get the first level file name from a given path
+ *
+ * Input
+ *  path: The path of the file/directory.
+ *  name_size: the size of 'name'.
+ * Output
+ *  name: the file name in the first level of the path.
+ * Return
+ *  The length of the path to jump to the next level.
+ */
+static int get_name_from_path(const char *path, char *name, size_t name_size)
+{
+	int i;
+	int name_len = 0;
+	int path_len = strlen(path);
+
+	if (path_len == 0)
+		return 0;
+
+	for (i = 0; i <= path_len && name_len + 1 < name_size; i++, path++) {
+		if (*path == '/' || *path == '\0') {
+			if (name_len == 0)
+				continue;
+
+			name[name_len] = 0;
+			return i;
+		}
+
+		name[name_len] = *path;
+		name_len++;
+	}
+
+	name[0] = 0;
+	return 0;
+}
+
+/*
+ * Create a inode for a given path
+ *
+ * Input
+ *   path: the path of the file/directory.
+ * Output
+ *   new: the new inode is created for the file/directory.
+ *        If path is '/', it is a copy of exfat->root.
+ *   dir_is_contiguous: Whether the clusters of the parent directory are
+ *                      contiguous.
+ * Return
+ *   0 on success
+ *   -error code on failure
+ */
+static int exfat_create_inode_by_path(struct exfat *exfat, const char *path,
+		struct exfat_inode **new, bool *dir_is_contiguous)
+{
+	int len, ret;
+	char name[PATH_MAX + 1];
+	struct exfat_inode *inode;
+	struct exfat_dentry *dentry_set;
+	struct exfat_lookup_filter filter;
+	const char *p_path = path;
+
+	inode = exfat_alloc_inode(ATTR_SUBDIR);
+	if (!inode)
+		return -ENOMEM;
+
+	*inode = *exfat->root;
+	*dir_is_contiguous = inode->is_contiguous;
+
+	do {
+		if ((inode->attr & ATTR_SUBDIR) == 0 && *p_path != '\0') {
+			ret = -ENOENT;
+			goto free_inode;
+		}
+
+		len = get_name_from_path(p_path, name, sizeof(name));
+		p_path += len;
+		if (name[0] == '\0' || len == 0) {
+			*new = inode;
+			return 0;
+		}
+
+		ret = exfat_utf16_enc(name, inode->name, NAME_BUFFER_SIZE);
+		if (ret < 0)
+			goto free_inode;
+
+		ret = exfat_lookup_file_by_utf16name(exfat, inode, inode->name,
+						     &filter);
+		if (ret) {
+			if (ret == EOF)
+				ret = -ENOENT;
+			goto free_inode;
+		}
+
+		dentry_set = filter.out.dentry_set;
+		if (inode->dentry_set)
+			free(inode->dentry_set);
+		inode->dentry_set = dentry_set;
+		inode->dev_offset = filter.out.dev_offset;
+		inode->dentry_count = filter.out.dentry_count;
+		inode->attr = dentry_set[0].file_attr;
+		inode->first_clus = le32_to_cpu(dentry_set[1].stream_start_clu);
+		*dir_is_contiguous = inode->is_contiguous;
+		inode->is_contiguous =
+			(dentry_set[1].stream_flags & EXFAT_SF_CONTIGUOUS);
+		inode->size = le64_to_cpu(dentry_set[1].stream_size);
+	} while (1);
+
+free_inode:
+	exfat_free_inode(inode);
+
+	return ret;
+}
+
+/*
+ * Get the position of the next directory entry
+ *
+ * Input
+ *   is_contiguous: Whether the cluster chain where the directory entries are
+ *                  located is continuous.
+ *   dentry_off:    The position of the current directory entry.
+ * Output
+ *   dentry_off:    The position of the next directory entry.
+ * Return
+ *   0 on success
+ *   -error code on failure
+ */
+static int exfat_get_next_dentry_offset(struct exfat *exfat, bool is_contiguous,
+			off_t *dentry_off)
+{
+	int ret;
+	clus_t clu;
+	unsigned int offset;
+
+	if (is_contiguous) {
+		*dentry_off += DENTRY_SIZE;
+		return 0;
+	}
+
+	ret = exfat_o2c(exfat, *dentry_off, &clu, &offset);
+	if (ret)
+		return ret;
+
+	if (offset + DENTRY_SIZE == exfat->clus_size) {
+		ret = exfat_get_next_clus(exfat, clu, &clu);
+		if (ret) {
+			exfat_err("failed to get next dentry offset 0x%lx\n",
+					*dentry_off);
+			return ret;
+		}
+
+		if (!exfat_heap_clus(exfat, clu)) {
+			exfat_err("cluster %u is not in cluster heap\n", clu);
+			return -ERANGE;
+		}
+
+		*dentry_off = exfat_c2o(exfat, clu);
+	} else
+		*dentry_off += DENTRY_SIZE;
+
+	return 0;
+}
+
+struct show_dentry {
+	__u8 type;
+	const char *type_name;
+	void (*show)(struct exfat_dentry *ed);
+};
+
+static void exfat_show_file_dentry(struct exfat_dentry *ed)
+{
+	uint16_t checksum = calc_dentry_set_checksum(ed, ed->file_num_ext + 1);
+
+	dump_dentry_field("SecondaryCount", "%u", ed->file_num_ext);
+	if (checksum == le16_to_cpu(ed->file_checksum))
+		dump_dentry_field("SetChecksum", "0x%04X", checksum);
+	else
+		dump_dentry_field("SetChecksum", "0x%04X(expected: 0x%04X)",
+				le16_to_cpu(ed->file_checksum), checksum);
+	dump_dentry_field("FileAttributes", "0x%04X", le16_to_cpu(ed->file_attr));
+	dump_dentry_field("CreateTimestamp", "0x%08X", le32_to_cpu(ed->file_create_time));
+	dump_dentry_field("LastModifiedTimestamp", "0x%08X", le32_to_cpu(ed->file_modify_time));
+	dump_dentry_field("LastAccessedTimestamp", "0x%08X", le32_to_cpu(ed->file_access_time));
+	dump_dentry_field("Create10msIncrement", "%u", ed->file_create_time_ms);
+	dump_dentry_field("LastModified10msIncrement", "%u", ed->file_modify_time_ms);
+	dump_dentry_field("CreateUtcOffset", "%u", ed->file_create_tz);
+	dump_dentry_field("LastModifiedUtcOffset", "%u", ed->file_modify_tz);
+	dump_dentry_field("LastAccessedUtcOffset", "%u", ed->file_access_tz);
+}
+
+static void exfat_show_stream_dentry(struct exfat_dentry *ed)
+{
+	dump_dentry_field("NameLength", "%u", ed->stream_name_len);
+	dump_dentry_field("NameHash", "0x%04X", le16_to_cpu(ed->stream_name_hash));
+	dump_dentry_field("ValidDataLength", "%" PRIu64, le64_to_cpu(ed->stream_valid_size));
+	dump_dentry_field("FirstCluster", "%u", le32_to_cpu(ed->stream_start_clu));
+	dump_dentry_field("DataLength", "%" PRIu64, le64_to_cpu(ed->stream_size));
+}
+
+static void exfat_show_bytes(const char *name, unsigned char *bytes, int n)
+{
+	char buf[64];
+	int i, len = 0;
+
+	for (i = 0; i < n && len < sizeof(buf); i++)
+		len += snprintf(buf + len, sizeof(buf), "%02X", bytes[i]);
+
+	exfat_info("%-33s  %s\n", name, buf);
+}
+
+#define dump_bytes_field(name, feild)	\
+	exfat_show_bytes("   " name ":", (unsigned char *)feild, sizeof(feild))
+
+static void exfat_show_name_dentry(struct exfat_dentry *ed)
+{
+	dump_bytes_field("FileName", ed->name_unicode);
+}
+
+static void exfat_show_bitmap_entry(struct exfat_dentry *ed)
+{
+	dump_dentry_field("BitmapFlags", "0x%02X", ed->dentry.bitmap.flags);
+	dump_dentry_field("FirstCluster", "%u", le32_to_cpu(ed->bitmap_start_clu));
+	dump_dentry_field("DataLength", "%" PRIu64, le64_to_cpu(ed->bitmap_size));
+}
+
+static void exfat_show_upcase_entry(struct exfat_dentry *ed)
+{
+	dump_dentry_field("TableChecksum", "0x%08X", le32_to_cpu(ed->upcase_checksum));
+	dump_dentry_field("FirstCluster", "%u", le32_to_cpu(ed->upcase_start_clu));
+	dump_dentry_field("DataLength", "%" PRIu64, le64_to_cpu(ed->upcase_size));
+}
+
+static void exfat_show_volume_entry(struct exfat_dentry *ed)
+{
+	dump_dentry_field("CharacterCount", "%u", ed->vol_char_cnt);
+	dump_bytes_field("VolumeLabel", ed->vol_label);
+}
+
+static void exfat_show_guid_entry(struct exfat_dentry *ed)
+{
+	dump_dentry_field("SecondaryCount", "%u", ed->dentry.guid.num_ext);
+	dump_dentry_field("SetChecksum", "0x%04X", le16_to_cpu(ed->dentry.guid.checksum));
+	dump_dentry_field("GeneralPrimaryFlags", "0x%04X", le16_to_cpu(ed->dentry.guid.flags));
+	dump_bytes_field("VolumeGuid", ed->dentry.guid.guid);
+}
+
+static void exfat_show_vendor_ext_dentry(struct exfat_dentry *ed)
+{
+	dump_bytes_field("VendorGuid", ed->dentry.vendor_ext.guid);
+	dump_bytes_field("VendorDefined", ed->dentry.vendor_ext.vendor_defined);
+}
+
+static void exfat_show_vendor_alloc_dentry(struct exfat_dentry *ed)
+{
+	dump_bytes_field("VendorGuid", ed->dentry.vendor_alloc.guid);
+	dump_bytes_field("VendorDefined", ed->dentry.vendor_alloc.vendor_defined);
+	dump_dentry_field("FirstCluster", "%u", le32_to_cpu(ed->vendor_alloc_start_clu));
+	dump_dentry_field("DataLength", "%" PRIu64, le64_to_cpu(ed->vendor_alloc_size));
+}
+
+static struct show_dentry show_dentry_array[] = {
+	{EXFAT_FILE, "File", exfat_show_file_dentry},
+	{EXFAT_STREAM, "Stream Extension", exfat_show_stream_dentry},
+	{EXFAT_NAME, "File Name", exfat_show_name_dentry},
+	{EXFAT_VENDOR_EXT, "Vendor Extension", exfat_show_vendor_ext_dentry},
+	{EXFAT_VENDOR_ALLOC, "Vendor Allocation", exfat_show_vendor_alloc_dentry},
+	{EXFAT_BITMAP, "Allocation Bitmap", exfat_show_bitmap_entry},
+	{EXFAT_UPCASE, "Up-case Table", exfat_show_upcase_entry},
+	{EXFAT_VOLUME, "Volume Label", exfat_show_volume_entry},
+	{EXFAT_GUID, "Volume GUID", exfat_show_guid_entry},
+	{EXFAT_PADDING, "TexFAT Padding", NULL},
+	{EXFAT_LAST, "Unused", NULL}
+};
+
+/*
+ * Print a directory entry
+ *
+ * Input
+ *   ed: The directory entry will be printed.
+ *   index: The entry index in directory entry set.
+ *   dentry_off: The position of the directory entry.
+ */
+static void exfat_show_dentry(struct exfat *exfat, struct exfat_dentry *ed,
+		unsigned int index, off_t dentry_off)
+{
+	int i;
+	struct show_dentry *sd = NULL;
+
+	for (i = 0; i < sizeof(show_dentry_array) / sizeof(*sd); i++) {
+		if (show_dentry_array[i].type == ed->type) {
+			sd = show_dentry_array + i;
+			break;
+		}
+	}
+
+	if (sd)
+		exfat_info("%d. %s Directory Entry\n", index,
+				sd->type_name);
+	else if (IS_EXFAT_DELETED(ed->type))
+		exfat_info("%d. Deleted Directory Entry\n", index);
+	else
+		exfat_info("%d. Unknown Directory Entry\n", index);
+
+	dump_dentry_field("Position", "0x%llX", (unsigned long long)dentry_off);
+	dump_dentry_field("Entrytype", "0x%02X", ed->type);
+
+	if (IS_EXFAT_SEC(ed->type))
+		dump_dentry_field("GeneralSecondaryFlags", "0x%02X", ed->stream_flags);
+
+	if (sd && sd->show)
+		sd->show(ed);
+}
+
+/*
+ * Print the directory entry set of the file/directory
+ *
+ * Input:
+ *   inode: it contains a copy of the directory entry set that will be printed.
+ *   dir_is_contiguous: Whether the clusters of the parent directory are
+ *                      contiguous.
+ */
+static void exfat_show_dentry_set(struct exfat *exfat,
+		struct exfat_inode *inode, bool dir_is_contiguous)
+{
+	int i;
+	struct exfat_dentry *ed;
+	off_t dentry_off;
+
+	ed = inode->dentry_set;
+	dentry_off = inode->dev_offset;
+
+	for (i = 0; i < inode->dentry_count; i++, ed++) {
+		exfat_show_dentry(exfat, ed, i, dentry_off);
+
+		if (i < inode->dentry_count - 1)
+			exfat_get_next_dentry_offset(exfat,
+					dir_is_contiguous, &dentry_off);
+	}
+}
+
+static int exfat_show_dentry_set_by_path(struct exfat *exfat, const char *path)
+{
+	int ret;
+	bool dir_is_contiguous;
+	struct exfat_inode *inode;
+
+	ret = exfat_create_inode_by_path(exfat, path, &inode,
+			&dir_is_contiguous);
+	if (ret)
+		return ret;
+
+	exfat_info("\n");
+	exfat_show_dentry_set(exfat, inode, dir_is_contiguous);
+
+	exfat_free_inode(inode);
+	return ret;
+}
+
 int main(int argc, char *argv[])
 {
 	int c;
@@ -230,6 +591,7 @@ int main(int argc, char *argv[])
 	struct exfat_user_input ui;
 	bool version_only = false;
 	struct exfat *exfat;
+	const char *path = NULL;
 
 	init_user_input(&ui);
 	ui.writeable = false;
@@ -238,10 +600,13 @@ int main(int argc, char *argv[])
 		exfat_err("failed to init locale/codeset\n");
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "iVh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "iVhd:", opts, NULL)) != EOF)
 		switch (c) {
 		case 'V':
 			version_only = true;
+			break;
+		case 'd':
+			path = optarg;
 			break;
 		case '?':
 		case 'h':
@@ -256,7 +621,7 @@ int main(int argc, char *argv[])
 	if (argc - optind != 1)
 		usage();
 
-	ui.dev_name = argv[1];
+	ui.dev_name = argv[argc - 1];
 
 	ret = exfat_get_blk_dev_info(&ui, &bd);
 	if (ret < 0)
@@ -268,7 +633,10 @@ int main(int argc, char *argv[])
 		goto close_dev_fd;
 	}
 
-	ret = exfat_show_fs_info(exfat);
+	if (path)
+		ret = exfat_show_dentry_set_by_path(exfat, path);
+	else
+		ret = exfat_show_fs_info(exfat);
 
 	exfat_free_exfat(exfat);
 

--- a/include/exfat_dir.h
+++ b/include/exfat_dir.h
@@ -94,6 +94,7 @@ int exfat_add_dentry_set(struct exfat *exfat, struct exfat_dentry_loc *loc,
 			 bool need_next_loc);
 void exfat_calc_dentry_checksum(struct exfat_dentry *dentry,
 				uint16_t *checksum, bool primary);
+uint16_t calc_dentry_set_checksum(struct exfat_dentry *dset, int dcount);
 uint16_t exfat_calc_name_hash(struct exfat *exfat,
 			      __le16 *name, int len);
 

--- a/include/exfat_ondisk.h
+++ b/include/exfat_ondisk.h
@@ -57,6 +57,7 @@
 #define EXFAT_DELETE		~(0x80)
 #define IS_EXFAT_DELETED(x)	((x) < 0x80) /* deleted file (0x01~0x7F) */
 #define EXFAT_INVAL		0x80	/* invalid value */
+#define EXFAT_SEC		(EXFAT_INVAL | (1 << 6))
 #define EXFAT_BITMAP		0x81	/* allocation bitmap */
 #define EXFAT_UPCASE		0x82	/* upcase table */
 #define EXFAT_VOLUME		0x83	/* volume label */
@@ -69,6 +70,7 @@
 #define EXFAT_ACL		0xC2	/* stream entry */
 #define EXFAT_VENDOR_EXT	0xE0
 #define EXFAT_VENDOR_ALLOC	0xE1
+#define IS_EXFAT_SEC(x)		((x) >= EXFAT_SEC)
 
 /* checksum types */
 #define CS_DIR_ENTRY		0
@@ -238,6 +240,9 @@ struct exfat_dentry {
 #define file_create_time_ms		dentry.file.create_time_ms
 #define file_modify_time_ms		dentry.file.modify_time_ms
 #define file_access_time_ms		dentry.file.access_time_ms
+#define file_create_tz			dentry.file.create_tz
+#define file_modify_tz			dentry.file.modify_tz
+#define file_access_tz			dentry.file.access_tz
 #define stream_flags			dentry.stream.flags
 #define stream_name_len			dentry.stream.name_len
 #define stream_name_hash		dentry.stream.name_hash
@@ -252,5 +257,8 @@ struct exfat_dentry {
 #define upcase_start_clu		dentry.upcase.start_clu
 #define upcase_size			dentry.upcase.size
 #define upcase_checksum			dentry.upcase.checksum
+#define vendor_alloc_flags		dentry.vendor_alloc.flags
+#define vendor_alloc_start_clu		dentry.vendor_alloc.start_clu
+#define vendor_alloc_size		dentry.vendor_alloc.size
 
 #endif /* !_EXFAT_H */

--- a/lib/exfat_dir.c
+++ b/lib/exfat_dir.c
@@ -553,7 +553,7 @@ void exfat_calc_dentry_checksum(struct exfat_dentry *dentry,
 	}
 }
 
-static uint16_t calc_dentry_set_checksum(struct exfat_dentry *dset, int dcount)
+uint16_t calc_dentry_set_checksum(struct exfat_dentry *dset, int dcount)
 {
 	uint16_t checksum;
 	int i;

--- a/manpages/dump.exfat.8
+++ b/manpages/dump.exfat.8
@@ -3,6 +3,10 @@
 dump.exfat \- Show on-disk information of exfat filesystem
 .SH SYNOPSIS
 .B dump.exfat
+[
+.B \-d
+.I file-path
+]
 .I device
 .br
 .B dump.exfat \-V
@@ -15,3 +19,6 @@ Print on-disk information from given device that formatted by exFAT filesystem.
 .TP
 .B \-V
 Prints the version number and exits.
+.TP
+.BR \-d ", " \-\-dentry-set=\fIpath\fR
+Print information of directory entries from a given path that exits in the given device.

--- a/manpages/dump.exfat.8
+++ b/manpages/dump.exfat.8
@@ -37,3 +37,6 @@ Scan and print information of directory entries from a given path that exits in 
 .TP
 .BR \-r ", " \-\-recursive
 Scan and print information of directory entries from a given path recursively that exits in the given device. Only works with -s option.
+.TP
+.BR \-c ", " \-\-cluster-chain
+Print the cluster chain while printing the directory entry information. Only works with -d/-s option.

--- a/manpages/dump.exfat.8
+++ b/manpages/dump.exfat.8
@@ -7,12 +7,21 @@ dump.exfat \- Show on-disk information of exfat filesystem
 .B \-d
 .I file-path
 ]
+[
+.B \-s
+.I dir-path
+]
+[
+.B \-r
+]
 .I device
 .br
 .B dump.exfat \-V
 .SH DESCRIPTION
 .B dump.exfat
 Print on-disk information from given device that formatted by exFAT filesystem.
+
+Note: For printing information of directory entries, the absence of "double-link" does not indicate the cluster is not doubly allocated if the scan is not started from the root directory with the recursive option.
 
 .PP
 .SH OPTIONS
@@ -22,3 +31,9 @@ Prints the version number and exits.
 .TP
 .BR \-d ", " \-\-dentry-set=\fIpath\fR
 Print information of directory entries from a given path that exits in the given device.
+.TP
+.BR \-s ", " \-\-scan-dir=\fIdir-path\fR
+Scan and print information of directory entries from a given path that exits in the given device.
+.TP
+.BR \-r ", " \-\-recursive
+Scan and print information of directory entries from a given path recursively that exits in the given device. Only works with -s option.


### PR DESCRIPTION
This pull request add option -d/-s/-r to dump directory entry.

* Test logs
  - [dump-uncorrupted-fs-log.txt](https://github.com/user-attachments/files/19562491/dump-uncorrupted-fs-log.txt)
  - [dump-corrupted-fs.txt](https://github.com/user-attachments/files/19562492/dump-corrupted-fs.txt)
    - Run test_fsck.sh with
      ```diff
      --- a/tests/test_fsck.sh
      +++ b/tests/test_fsck.sh
      @@ -50,6 +50,9 @@ for TESTCASE in ${TESTCASE_LIST[*]}; do
                      cleanup
              fi
 
      +       ../dump/dump.exfat -s / -r ${IMAGE_FILE}
      +       continue
      +
              # Set up image file as loop device
              if [ $NEED_LOOPDEV ]; then
                      DEV_FILE=$(losetup -f "${IMAGE_FILE}" --show)
      ```
