### PR TITLE
exfatprogs: release 1.2.9 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,15 @@
+exfatprogs 1.2.9 - released 2025-05-12
+======================================
+
+NEW FEATURES :
+ * dump.exfat: support dumping directory entry sets,
+   which prints all fields of directory entries and
+   cluster chains. See a man page.
+
+CHANGES :
+ * exfatprogs: update the Github action for build test
+   with Debain + clang + lld.
+
 exfatprogs 1.2.8 - released 2025-03-04
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.2.8"
+#define EXFAT_PROGS_VERSION "1.2.9"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
exfatprogs 1.2.9 - released 2025-05-12
======================================

 NEW FEATURES :
  * dump.exfat: support dumping directory entry sets, which prints all fields of directory entries and cluster chains. See a man page.

 CHANGES :
  * exfatprogs: update the Github action for build test with Debain + clang + lld.