### PR TITLE
ci: Invoke apt-get with --update to run apt-get update before package installation

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,10 +19,10 @@ jobs:
     - uses: actions/checkout@v4
     - name: before test
       run: |
-        sudo apt-get update
-        sudo apt-get install linux-headers-$(uname -r) xz-utils \
-                             gcc-mips-linux-gnu qemu-system-mips \
-                             qemu-user
+        sudo apt-get --update --quiet --yes install \
+             linux-headers-$(uname -r) xz-utils \
+             gcc-mips-linux-gnu qemu-system-mips \
+             qemu-user
         git clone https://github.com/namjaejeon/linux-exfat-oot
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
         export PATH=/usr/local/lib:$PATH

--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -36,7 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Packages
-        run: apt update && apt -y install clang lld pkgconf xxd autoconf libtool automake make xz-utils
+        run: |
+          apt-get --update --quiet --yes install \
+            clang lld pkgconf xxd autoconf \
+            libtool automake make xz-utils
       - name: Autoconf and Configure
         run: |
           export LDFLAGS="-fuse-ld=lld"


### PR DESCRIPTION
Feature is available in apt 2.7.0 or later, part of Ubuntu since 24.04 (noble) and Debian 13 (trixie).

Take this as an opportunity to align the way apt is invoked in both workflows. Use the long version of all flags so it's less opaque how apt is invoked.