### PR TITLE
mkfs: add read-after-write verification for main boot sector

### DIFF
--- a/defrag/defrag.c
+++ b/defrag/defrag.c
@@ -167,7 +167,7 @@ static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
 		boot_calc_checksum(buf, bd->sector_size, is_boot_sec, &checksum);
 	}
 
-	ret = exfat_write_checksum_sector(bd, checksum, is_backup);
+	ret = exfat_write_checksum_sector(bd, NULL, checksum, is_backup);
 
 free_buf:
 	free(buf);

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -68,6 +68,7 @@ enum {
 
 struct exfat_blk_dev {
 	int dev_fd;
+	int verify_fd;
 	unsigned long long offset;
 	unsigned long long size;
 	unsigned int sector_size;
@@ -86,10 +87,12 @@ struct exfat_user_input {
 	unsigned int boundary_align;
 	bool pack_bitmap;
 	bool quick;
+	bool verify;
 	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
 	int volume_label_len;
 	unsigned int volume_serial;
 	const char *guid;
+	unsigned char *fat_table_buff;
 };
 
 struct exfat;
@@ -171,7 +174,8 @@ int exfat_read_sector(struct exfat_blk_dev *bd, void *buf,
 int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
 		unsigned int sec_off);
 int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
-		unsigned int checksum, bool is_backup);
+	struct exfat_user_input *ui, unsigned int checksum,
+	bool is_backup);
 char *exfat_conv_volume_label(struct exfat_dentry *vol_entry);
 int exfat_show_volume_serial(int fd);
 int exfat_set_volume_serial(struct exfat_blk_dev *bd,
@@ -193,7 +197,9 @@ int exfat_root_clus_count(struct exfat *exfat);
 int read_boot_sect(struct exfat_blk_dev *bdev, struct pbr **bs);
 int exfat_parse_ulong(const char *s, unsigned long *out);
 int exfat_check_name(__le16 *utf16_name, int len);
-
+int exfat_check_written_data(struct exfat_blk_dev *bd, const void *buf,
+				     size_t len, off_t off,
+				     const char *what);
 /*
  * Exfat Print
  */

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -3,6 +3,9 @@
  *   Copyright (C) 2019 Namjae Jeon <linkinjeon@kernel.org>
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -206,6 +209,16 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 
 	ret = 0;
 	bd->dev_fd = fd;
+
+	if (ui->verify) {
+		bd->verify_fd = open(ui->dev_name, O_RDONLY|O_DIRECT);
+		if (bd->verify_fd < 0) {
+			exfat_err("open %s O_DIRECT failed:%s\n", ui->dev_name,
+				strerror(errno));
+			close(fd);
+			ret = -1;
+		}
+	}
 out:
 	return ret;
 }
@@ -684,6 +697,45 @@ out:
 	return err;
 }
 
+int exfat_check_written_data(struct exfat_blk_dev *bd,
+				const void *buf, size_t len,
+				off_t off, const char *what)
+{
+	void *verify;
+	ssize_t n;
+	size_t sector = bd->sector_size;
+	int ret = 0;
+
+	ret = fsync(bd->dev_fd);
+	if (ret)
+		return ret;
+
+	off_t aligned_off = off & ~(sector - 1);
+	size_t head = off - aligned_off;
+	size_t aligned_len = ((head + len + sector - 1) / sector) * sector;
+
+	if (posix_memalign(&verify, sector, aligned_len))
+		return -ENOMEM;
+	memset(verify, 0, aligned_len);
+
+	n = exfat_read(bd->verify_fd, verify, aligned_len, aligned_off);
+	if (n != (ssize_t)aligned_len) {
+		exfat_debug("%s verify read failed (off=%llu, len=%zu)\n",
+					what, (unsigned long long)aligned_off,
+					aligned_len);
+		ret = -EIO;
+	}
+
+	if (memcmp(buf, (unsigned char *)verify + head, len) != 0) {
+		exfat_debug("%s verify mismatch (off=%llu)\n",
+					what, (unsigned long long)off);
+		ret = -EIO;
+	}
+
+	free(verify);
+	return ret;
+}
+
 int exfat_read_sector(struct exfat_blk_dev *bd, void *buf, unsigned int sec_off)
 {
 	int ret;
@@ -715,7 +767,8 @@ int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
 }
 
 int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
-		unsigned int checksum, bool is_backup)
+		struct exfat_user_input *ui, unsigned int checksum,
+		bool is_backup)
 {
 	__le32 *checksum_buf;
 	int ret = 0;
@@ -736,6 +789,17 @@ int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
 	if (ret) {
 		exfat_err("checksum sector write failed\n");
 		goto free;
+	}
+
+	if (ui && ui->verify) {
+		ret = exfat_check_written_data(bd,
+				checksum_buf, bd->sector_size,
+				sec_idx * bd->sector_size,
+				"checksum sector");
+		if (ret) {
+			exfat_err("checksum sector verification failed (read-back mismatch)\n");
+			goto free;
+		}
 	}
 
 free:
@@ -775,7 +839,8 @@ free_ppbr:
 	return ret;
 }
 
-static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
+static int exfat_update_boot_checksum(struct exfat_blk_dev *bd,
+	struct exfat_user_input *ui, bool is_backup)
 {
 	unsigned int checksum = 0;
 	int ret, sec_idx, backup_sec_idx = 0;
@@ -807,7 +872,7 @@ static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
 			&checksum);
 	}
 
-	ret = exfat_write_checksum_sector(bd, checksum, is_backup);
+	ret = exfat_write_checksum_sector(bd, ui, checksum, is_backup);
 
 free_buf:
 	free(buf);
@@ -861,13 +926,13 @@ int exfat_set_volume_serial(struct exfat_blk_dev *bd,
 		goto free_ppbr;
 	}
 
-	ret = exfat_update_boot_checksum(bd, 0);
+	ret = exfat_update_boot_checksum(bd, ui, 0);
 	if (ret < 0) {
 		exfat_err("main checksum update failed\n");
 		goto free_ppbr;
 	}
 
-	ret = exfat_update_boot_checksum(bd, 1);
+	ret = exfat_update_boot_checksum(bd, ui, 1);
 	if (ret < 0)
 		exfat_err("backup checksum update failed\n");
 free_ppbr:

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -16,6 +16,8 @@ mkfs.exfat \- create an exFAT filesystem
 ] [
 .B \-f
 ] [
+.B \-C
+] [
 .B \-h
 ] [
 .B \-L
@@ -103,6 +105,16 @@ _
 .BR \-f ", " \-\-full\-format
 Performs a full format.
 This zeros the entire disk device while creating the exFAT filesystem.
+.TP
+.BR \-C ", " \-\-verify\-written
+Verify filesystem metadata by reading it back after writing.
+This option performs read-back verification of critical exFAT metadata
+(boot record, FAT, allocation bitmap, upcase table, and root directory)
+after each formatting stage.
+It is useful for detecting broken storage devices or devices that falsely
+report successful writes without actually persisting data.
+This option may slightly degrade formatting performance and is therefore
+disabled by default.
 .TP
 .BR \-h ", " \-\-help
 Prints the help and exit.

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -127,6 +127,17 @@ static int exfat_write_boot_sector(struct exfat_blk_dev *bd,
 		goto free_ppbr;
 	}
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				ppbr, bd->sector_size,
+				sec_idx * bd->sector_size,
+				"boot sector");
+		if (ret) {
+			exfat_err("boot sector verification failed (read-back mismatch)\n");
+			goto free_ppbr;
+		}
+	}
+
 	boot_calc_checksum((unsigned char *)ppbr, bd->sector_size,
 		true, checksum);
 
@@ -136,7 +147,8 @@ free_ppbr:
 }
 
 static int exfat_write_extended_boot_sectors(struct exfat_blk_dev *bd,
-		unsigned int *checksum, bool is_backup)
+		struct exfat_user_input *ui, unsigned int *checksum,
+		bool is_backup)
 {
 	char *peb;
 	__le16 *peb_signature;
@@ -161,6 +173,17 @@ static int exfat_write_extended_boot_sectors(struct exfat_blk_dev *bd,
 			goto free_peb;
 		}
 
+		if (ui->verify) {
+			ret = exfat_check_written_data(bd,
+					peb, bd->sector_size,
+					(sec_idx - 1) * bd->sector_size,
+					"extended boot sector");
+			if (ret) {
+				exfat_err("extended boot sector verification failed (read-back mismatch)\n");
+				goto free_peb;
+			}
+		}
+
 		boot_calc_checksum((unsigned char *) peb, bd->sector_size,
 			false, checksum);
 	}
@@ -171,7 +194,8 @@ free_peb:
 }
 
 static int exfat_write_oem_sector(struct exfat_blk_dev *bd,
-		unsigned int *checksum, bool is_backup)
+		struct exfat_user_input *ui, unsigned int *checksum,
+		bool is_backup)
 {
 	char *oem;
 	int ret = 0;
@@ -191,6 +215,17 @@ static int exfat_write_oem_sector(struct exfat_blk_dev *bd,
 		goto free_oem;
 	}
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				oem, bd->sector_size,
+				sec_idx * bd->sector_size,
+				"oem sector");
+		if (ret) {
+			exfat_err("oem sector verification failed (read-back mismatch)\n");
+			goto free_oem;
+		}
+	}
+
 	boot_calc_checksum((unsigned char *)oem, bd->sector_size, false,
 		checksum);
 
@@ -200,6 +235,17 @@ static int exfat_write_oem_sector(struct exfat_blk_dev *bd,
 		exfat_err("reserved sector write failed\n");
 		ret = -1;
 		goto free_oem;
+	}
+
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				oem, bd->sector_size,
+				(sec_idx + 1) * bd->sector_size,
+				"reserved sector");
+		if (ret) {
+			exfat_err("reserved sector verification failed (read-back mismatch)\n");
+			goto free_oem;
+		}
 	}
 
 	boot_calc_checksum((unsigned char *)oem, bd->sector_size, false,
@@ -219,18 +265,18 @@ static int exfat_create_volume_boot_record(struct exfat_blk_dev *bd,
 	ret = exfat_write_boot_sector(bd, ui, &checksum, is_backup);
 	if (ret)
 		return ret;
-	ret = exfat_write_extended_boot_sectors(bd, &checksum, is_backup);
+	ret = exfat_write_extended_boot_sectors(bd, ui, &checksum, is_backup);
 	if (ret)
 		return ret;
-	ret = exfat_write_oem_sector(bd, &checksum, is_backup);
+	ret = exfat_write_oem_sector(bd, ui, &checksum, is_backup);
 	if (ret)
 		return ret;
 
-	return exfat_write_checksum_sector(bd, checksum, is_backup);
+	return exfat_write_checksum_sector(bd, ui, checksum, is_backup);
 }
 
-static int write_fat_entry(int fd, __le32 clu,
-		unsigned long long offset)
+static int write_fat_entry(struct exfat_user_input *ui, int fd,
+		__le32 clu, unsigned long long offset)
 {
 	int nbyte;
 	off_t fat_entry_offset = finfo.fat_byte_off + (offset * sizeof(__le32));
@@ -240,6 +286,11 @@ static int write_fat_entry(int fd, __le32 clu,
 		exfat_err("write failed, offset : %llu, clu : %x\n",
 			offset, clu);
 		return -1;
+	}
+
+	if (ui->verify) {
+		memcpy(ui->fat_table_buff + offset * sizeof(__le32),
+			(__u8 *)&clu, sizeof(__le32));
 	}
 
 	return 0;
@@ -254,12 +305,12 @@ static int write_fat_entries(struct exfat_user_input *ui, int fd,
 	count = clu + round_up(length, ui->cluster_size) / ui->cluster_size;
 
 	for (; clu < count - 1; clu++) {
-		ret = write_fat_entry(fd, cpu_to_le32(clu + 1), clu);
+		ret = write_fat_entry(ui, fd, cpu_to_le32(clu + 1), clu);
 		if (ret)
 			return ret;
 	}
 
-	ret = write_fat_entry(fd, cpu_to_le32(EXFAT_EOF_CLUSTER), clu);
+	ret = write_fat_entry(ui, fd, cpu_to_le32(EXFAT_EOF_CLUSTER), clu);
 	if (ret)
 		return ret;
 
@@ -270,48 +321,81 @@ static int exfat_create_fat_table(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
 	int ret, clu;
+	unsigned int fat_table_entries = 0;
+
+	if (ui->verify) {
+		fat_table_entries =
+			EXFAT_FIRST_CLUSTER +
+			DIV_ROUND_UP(finfo.bitmap_byte_len, ui->cluster_size) +
+			DIV_ROUND_UP(finfo.ut_byte_len, ui->cluster_size) +
+			DIV_ROUND_UP(finfo.root_byte_len, ui->cluster_size);
+
+		ui->fat_table_buff = calloc(fat_table_entries, sizeof(__le32));
+		if (!ui->fat_table_buff)
+			return -ENOMEM;
+	}
 
 	/* fat entry 0 should be media type field(0xF8) */
-	ret = write_fat_entry(bd->dev_fd, cpu_to_le32(0xfffffff8), 0);
+	ret = write_fat_entry(ui, bd->dev_fd, cpu_to_le32(0xfffffff8), 0);
 	if (ret) {
 		exfat_err("fat 0 entry write failed\n");
-		return ret;
+		goto free_fat_table_buff;
 	}
 
 	/* fat entry 1 is historical precedence(0xFFFFFFFF) */
-	ret = write_fat_entry(bd->dev_fd, cpu_to_le32(0xffffffff), 1);
+	ret = write_fat_entry(ui, bd->dev_fd, cpu_to_le32(0xffffffff), 1);
 	if (ret) {
 		exfat_err("fat 1 entry write failed\n");
-		return ret;
+		goto free_fat_table_buff;
 	}
 
 	/* write bitmap entries */
 	clu = write_fat_entries(ui, bd->dev_fd, EXFAT_FIRST_CLUSTER,
 		finfo.bitmap_byte_len);
-	if (clu < 0)
-		return ret;
+	if (clu < 0) {
+		ret = clu;
+		goto free_fat_table_buff;
+	}
 
 	/* write upcase table entries */
 	clu = write_fat_entries(ui, bd->dev_fd, clu + 1, finfo.ut_byte_len);
-	if (clu < 0)
-		return ret;
+	if (clu < 0) {
+		ret = clu;
+		goto free_fat_table_buff;
+	}
 
 	/* write root directory entries */
 	clu = write_fat_entries(ui, bd->dev_fd, clu + 1, finfo.root_byte_len);
-	if (clu < 0)
-		return ret;
+	if (clu < 0) {
+		ret = clu;
+		goto free_fat_table_buff;
+	}
 
 	finfo.used_clu_cnt = clu + 1 - EXFAT_FIRST_CLUSTER;
 	exfat_debug("Total used cluster count : %d\n", finfo.used_clu_cnt);
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				ui->fat_table_buff, fat_table_entries * sizeof(__le32),
+				finfo.fat_byte_off,
+				"fat table");
+		if (ret)
+			exfat_err("fat table verification failed (read-back mismatch)\n");
+	}
+
+free_fat_table_buff:
+	if (ui->verify)
+		free(ui->fat_table_buff);
 	return ret;
 }
 
-static int exfat_create_bitmap(struct exfat_blk_dev *bd)
+static int exfat_create_bitmap(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui)
 {
 	char *bitmap;
 	unsigned int full_bytes, rem_bits, zero_offset;
 	unsigned int nbytes;
+	int ret = 0;
 
 	bitmap = malloc(finfo.bitmap_byte_len);
 	if (!bitmap)
@@ -338,6 +422,18 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd)
 			nbytes, finfo.bitmap_byte_len);
 		free(bitmap);
 		return -1;
+	}
+
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				bitmap, finfo.bitmap_byte_len,
+				finfo.bitmap_byte_off,
+				"bitmap");
+		if (ret) {
+			exfat_err("bitmap verification failed (read-back mismatch)\n");
+			free(bitmap);
+			return ret;
+		}
 	}
 
 	free(bitmap);
@@ -396,6 +492,17 @@ static int exfat_create_root_dir(struct exfat_blk_dev *bd,
 		return -1;
 	}
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				ed, dentries_len,
+				finfo.root_byte_off,
+				"root directory");
+		if (ret) {
+			exfat_err("root directory verification failed (read-back mismatch)\n");
+			return ret;
+		}
+
+	}
 	return 0;
 }
 
@@ -409,6 +516,7 @@ static void usage(void)
 		"\t-b | --boundary-align=size(or suffixed by 'K' or 'M')  Specify boundary alignment\n"
 		"\t     --pack-bitmap                                     Move bitmap into FAT segment\n"
 		"\t-f | --full-format                                     Full format\n"
+		"\t-C | --check-written                                   Verify written filesystem metadata by read-back\n"
 		"\t-V | --version                                         Show version\n"
 		"\t-q | --quiet                                           Print only errors\n"
 		"\t-v | --verbose                                         Print debug\n"
@@ -428,6 +536,7 @@ static const struct option opts[] = {
 	{"boundary-align",	required_argument,	NULL,	'b' },
 	{"pack-bitmap",		no_argument,		NULL,	PACK_BITMAP },
 	{"full-format",		no_argument,		NULL,	'f' },
+	{"check-written",	no_argument,		NULL,	'C' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"quiet",		no_argument,		NULL,	'q' },
 	{"verbose",		no_argument,		NULL,	'v' },
@@ -580,13 +689,13 @@ static int make_exfat(struct exfat_blk_dev *bd, struct exfat_user_input *ui)
 		return ret;
 
 	exfat_info("Allocation bitmap creation: ");
-	ret = exfat_create_bitmap(bd);
+	ret = exfat_create_bitmap(bd, ui);
 	exfat_info("%s\n", ret ? "failed" : "done");
 	if (ret)
 		return ret;
 
 	exfat_info("Upcase table creation: ");
-	ret = exfat_create_upcase_table(bd);
+	ret = exfat_create_upcase_table(bd, ui);
 	exfat_info("%s\n", ret ? "failed" : "done");
 	if (ret)
 		return ret;
@@ -640,7 +749,7 @@ int main(int argc, char *argv[])
 		exfat_err("failed to init locale/codeset\n");
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fVqvh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fCVqvh", opts, NULL)) != EOF)
 		switch (c) {
 		/*
 		 * Make 'n' option fallthrough to 'L' option for for backward
@@ -709,6 +818,9 @@ int main(int argc, char *argv[])
 		case 'f':
 			ui.quick = false;
 			break;
+		case 'C':
+			ui.verify = true;
+			break;
 		case 'V':
 			version_only = true;
 			break;
@@ -765,6 +877,8 @@ int main(int argc, char *argv[])
 	ret = fsync(bd.dev_fd);
 close:
 	close(bd.dev_fd);
+	if (ui.verify)
+		close(bd.verify_fd);
 out:
 	if (!ret)
 		exfat_info("\nexFAT format complete!\n");

--- a/mkfs/mkfs.h
+++ b/mkfs/mkfs.h
@@ -27,6 +27,6 @@ struct exfat_mkfs_info {
 
 extern struct exfat_mkfs_info finfo;
 
-int exfat_create_upcase_table(struct exfat_blk_dev *bd);
+int exfat_create_upcase_table(struct exfat_blk_dev *bd, struct exfat_user_input *ui);
 
 #endif /* !_MKFS_H */

--- a/mkfs/upcase.c
+++ b/mkfs/upcase.c
@@ -13,14 +13,28 @@
 #include "mkfs.h"
 #include "upcase_table.h"
 
-int exfat_create_upcase_table(struct exfat_blk_dev *bd)
+int exfat_create_upcase_table(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui)
 {
 	int nbytes;
+	int ret;
 
 	nbytes = pwrite(bd->dev_fd, default_upcase_table,
 			EXFAT_UPCASE_TABLE_SIZE, finfo.ut_byte_off);
 	if (nbytes != EXFAT_UPCASE_TABLE_SIZE)
 		return -1;
+
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				default_upcase_table,
+				EXFAT_UPCASE_TABLE_SIZE,
+				finfo.ut_byte_off,
+				"upcase table");
+		if (ret) {
+			exfat_err("upcase table verification failed (read-back mismatch)\n");
+			return ret;
+		}
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Recently, we encountered a confusing behavior during testing and would like to ask for your insight.

We have a batch of SD cards that fail to format on Windows, where the system reports:
“Windows was unable to complete the format.”

<img width="344" height="116" alt="image" src="https://github.com/user-attachments/assets/62e8e14c-fc67-4034-9333-5122f2567c03" />

**However, on the same devices, running mkfs.exfat on Linux completes successfully and reports no error.**

---

mkfs.exfat assumes that successful write system calls imply that data is eventually committed to persistent storage.

On some removable flash devices (e.g. low-quality SD cards, USB flash drives), this assumption does not hold. Such devices may:

- Acknowledge write requests without programming NAND ("fake write")
- Serve subsequent reads from internal controller cache

As a result, mkfs.exfat may report successful filesystem creation even though critical on-disk structures were never persisted.

Therefore, we would like to provide a warning for such SD cards, indicating that `mkfs.exfat` could not be completed successfully.

This patch adds a sanity check after writing the main boot sector to ensure the data can be read back correctly, improving robustness on devices with unreliable write behavior.

I have already tested this patch on the same SD card, and it now correctly reports an error indicating that formatting could not be completed.
