### PR TITLE
fsck: change 0x80 entries to deleted file entries to avoid  bogus dentry

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -936,7 +936,7 @@ skip_dset:
 			break;
 		if (need_delete) {
 			exfat_de_iter_get_dirty(iter, i, &dentry);
-			dentry->type &= EXFAT_DELETE;
+			dentry->type = EXFAT_DELETE;
 		}
 	}
 	*skip_dentries = i;
@@ -1424,7 +1424,7 @@ static int read_children(struct exfat_fsck *fsck, struct exfat_inode *dir)
 				struct exfat_dentry *dentry;
 
 				exfat_de_iter_get_dirty(de_iter, 0, &dentry);
-				dentry->type &= EXFAT_DELETE;
+				dentry->type = EXFAT_DELETE;
 			}
 			break;
 		}


### PR DESCRIPTION
When a broken image like this:

```shell
00203080   80 02 81 78 20 00 00 00  3A 40 41 5C 3A 40 41 5C
           --
00203090   3A 40 41 5C 96 96 80 80  80 00 00 00 00 00 00 00
002030A0   C0 01 00 03 2A A8 00 00  00 00 00 00 00 00 00 00
002030B0   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
002030C0   C1 00 61 00 61 00 61 00  00 00 00 00 00 00 00 00
002030D0   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
002030E0   85 02 6B 92 20 00 00 00  3B 40 41 5C 3B 40 41 5C
002030F0   3B 40 41 5C B9 B9 80 80  80 00 00 00 00 00 00 00
00203100   C0 01 00 03 2B 50 00 00  00 00 00 00 00 00 00 00
00203110   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
00203120   C1 00 62 00 62 00 62 00  00 00 00 00 00 00 00 00
00203130   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
```
If run `fsck.exfat -y /dev/block/sda`，broken image will be:

```shell
00203080   00 02 81 78 20 00 00 00  3A 40 41 5C 3A 40 41 5C
           --
00203090   3A 40 41 5C 96 96 80 80  80 00 00 00 00 00 00 00
002030A0   40 01 00 03 2A A8 00 00  00 00 00 00 00 00 00 00
002030B0   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
002030C0   41 00 61 00 61 00 61 00  00 00 00 00 00 00 00 00
002030D0   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
002030E0   85 02 6B 92 20 00 00 00  3B 40 41 5C 3B 40 41 5C
002030F0   3B 40 41 5C B9 B9 80 80  80 00 00 00 00 00 00 00
00203100   C0 01 00 03 2B 50 00 00  00 00 00 00 00 00 00 00
00203110   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
00203120   C1 00 62 00 62 00 62 00  00 00 00 00 00 00 00 00
00203130   00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
```

When create a new long-name file, exfat filesystem will report `error, found bogus dentry(7) beyond unused empty group(4) (start_clu : 5, cur_clu : 5)`

So, we should change 0x80 entries to deleted file entries to avoid  bogus dentryBogus entry.
