### PR TITLE
exfatprogs: adjust exit code

### DIFF
--- a/dump/dump.c
+++ b/dump/dump.c
@@ -989,5 +989,5 @@ close_dev_fd:
 	close(bd.dev_fd);
 
 out:
-	return ret;
+	return (ret ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/label/label.c
+++ b/label/label.c
@@ -127,5 +127,5 @@ int main(int argc, char *argv[])
 close_fd_out:
 	close(bd.dev_fd);
 out:
-	return ret;
+	return (ret ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -423,8 +423,10 @@ char *exfat_conv_volume_label(struct exfat_dentry *vol_entry)
 	__le16 disk_label[VOLUME_LABEL_MAX_LEN];
 
 	volume_label = malloc(VOLUME_LABEL_BUFFER_SIZE);
-	if (!volume_label)
+	if (!volume_label) {
+		exfat_err("Cannot allocate volume_label: out of memory\n");
 		return NULL;
+	}
 
 	memcpy(disk_label, vol_entry->vol_label, sizeof(disk_label));
 	memset(volume_label, 0, VOLUME_LABEL_BUFFER_SIZE);
@@ -776,8 +778,10 @@ int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
 	unsigned int sec_idx = CHECKSUM_SEC_IDX;
 
 	checksum_buf = malloc(bd->sector_size);
-	if (!checksum_buf)
+	if (!checksum_buf) {
+		exfat_err("Cannot allocate checksum_buf: out of memory\n");
 		return -1;
+	}
 
 	if (is_backup)
 		sec_idx += BACKUP_BOOT_SEC_IDX;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -157,8 +157,10 @@ static int exfat_write_extended_boot_sectors(struct exfat_blk_dev *bd,
 	unsigned int sec_idx = EXBOOT_SEC_IDX;
 
 	peb = malloc(bd->sector_size);
-	if (!peb)
+	if (!peb) {
+		exfat_err("Cannot allocate peb: out of memory\n");
 		return -1;
+	}
 
 	if (is_backup)
 		sec_idx += BACKUP_BOOT_SEC_IDX;
@@ -398,8 +400,10 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd,
 	int ret = 0;
 
 	bitmap = malloc(finfo.bitmap_byte_len);
-	if (!bitmap)
+	if (!bitmap) {
+		exfat_err("Cannot allocate bitmap: out of memory\n");
 		return -1;
+	}
 
 	full_bytes = finfo.used_clu_cnt / 8;
 	rem_bits = finfo.used_clu_cnt % 8;
@@ -884,5 +888,5 @@ out:
 		exfat_info("\nexFAT format complete!\n");
 	else
 		exfat_err("\nexFAT format fail!\n");
-	return ret;
+	return (ret ? EXIT_FAILURE : EXIT_SUCCESS);
 }

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -152,5 +152,5 @@ close_fd_out:
 	if (exfat)
 		exfat_free_exfat(exfat);
 out:
-	return ret;
+	return (ret ? EXIT_FAILURE : EXIT_SUCCESS);
 }


### PR DESCRIPTION
I plan to update all malloc() failure paths in exfatprogs to return -ENOMEM instead, so that callers can correctly distinguish out-of-memory conditions from I/O errors.