### PR TITLE
mkfs.exfat: discard blocks prior to write outs

### DIFF
--- a/defrag/defrag.c
+++ b/defrag/defrag.c
@@ -167,7 +167,7 @@ static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
 		boot_calc_checksum(buf, bd->sector_size, is_boot_sec, &checksum);
 	}
 
-	ret = exfat_write_checksum_sector(bd, checksum, is_backup);
+	ret = exfat_write_checksum_sector(bd, NULL, checksum, is_backup);
 
 free_buf:
 	free(buf);

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -989,5 +989,5 @@ close_dev_fd:
 	close(bd.dev_fd);
 
 out:
-	return ret;
+	return ret ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -936,7 +936,7 @@ skip_dset:
 			break;
 		if (need_delete) {
 			exfat_de_iter_get_dirty(iter, i, &dentry);
-			dentry->type &= EXFAT_DELETE;
+			dentry->type = EXFAT_DELETE;
 		}
 	}
 	*skip_dentries = i;
@@ -1424,7 +1424,7 @@ static int read_children(struct exfat_fsck *fsck, struct exfat_inode *dir)
 				struct exfat_dentry *dentry;
 
 				exfat_de_iter_get_dirty(de_iter, 0, &dentry);
-				dentry->type &= EXFAT_DELETE;
+				dentry->type = EXFAT_DELETE;
 			}
 			break;
 		}

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -68,6 +68,7 @@ enum {
 
 struct exfat_blk_dev {
 	int dev_fd;
+	int verify_fd;
 	unsigned long long offset;
 	unsigned long long size;
 	unsigned int sector_size;
@@ -86,10 +87,12 @@ struct exfat_user_input {
 	unsigned int boundary_align;
 	bool pack_bitmap;
 	bool quick;
+	bool verify;
 	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
 	int volume_label_len;
 	unsigned int volume_serial;
 	const char *guid;
+	unsigned char *fat_table_buff;
 };
 
 struct exfat;
@@ -171,7 +174,8 @@ int exfat_read_sector(struct exfat_blk_dev *bd, void *buf,
 int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
 		unsigned int sec_off);
 int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
-		unsigned int checksum, bool is_backup);
+	struct exfat_user_input *ui, unsigned int checksum,
+	bool is_backup);
 char *exfat_conv_volume_label(struct exfat_dentry *vol_entry);
 int exfat_show_volume_serial(int fd);
 int exfat_set_volume_serial(struct exfat_blk_dev *bd,
@@ -193,7 +197,9 @@ int exfat_root_clus_count(struct exfat *exfat);
 int read_boot_sect(struct exfat_blk_dev *bdev, struct pbr **bs);
 int exfat_parse_ulong(const char *s, unsigned long *out);
 int exfat_check_name(__le16 *utf16_name, int len);
-
+int exfat_check_written_data(struct exfat_blk_dev *bd, const void *buf,
+				     size_t len, off_t off,
+				     const char *what);
 /*
  * Exfat Print
  */

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -76,6 +76,7 @@ struct exfat_blk_dev {
 	unsigned long long num_sectors;
 	unsigned int num_clusters;
 	unsigned int cluster_size;
+	bool isblk;
 };
 
 struct exfat_user_input {
@@ -88,6 +89,7 @@ struct exfat_user_input {
 	bool pack_bitmap;
 	bool quick;
 	bool verify;
+	bool discard;
 	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
 	int volume_label_len;
 	unsigned int volume_serial;
@@ -158,6 +160,7 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 ssize_t exfat_read(int fd, void *buf, size_t size, off_t offset);
 ssize_t exfat_write(int fd, void *buf, size_t size, off_t offset);
 ssize_t exfat_write_zero(int fd, size_t size, off_t offset);
+int exfat_discard_blocks(int fd, uint64_t start, uint64_t len);
 
 size_t exfat_utf16_len(const __le16 *str, size_t max_size);
 ssize_t exfat_utf16_enc(const char *in_str, __u16 *out_str, size_t out_size);

--- a/label/label.c
+++ b/label/label.c
@@ -127,5 +127,5 @@ int main(int argc, char *argv[])
 close_fd_out:
 	close(bd.dev_fd);
 out:
-	return ret;
+	return ret ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -3,6 +3,9 @@
  *   Copyright (C) 2019 Namjae Jeon <linkinjeon@kernel.org>
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
@@ -206,6 +209,16 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 
 	ret = 0;
 	bd->dev_fd = fd;
+
+	if (ui->verify) {
+		bd->verify_fd = open(ui->dev_name, O_RDONLY|O_DIRECT);
+		if (bd->verify_fd < 0) {
+			exfat_err("open %s O_DIRECT failed:%s\n", ui->dev_name,
+				strerror(errno));
+			close(fd);
+			ret = -1;
+		}
+	}
 out:
 	return ret;
 }
@@ -684,6 +697,45 @@ out:
 	return err;
 }
 
+int exfat_check_written_data(struct exfat_blk_dev *bd,
+				const void *buf, size_t len,
+				off_t off, const char *what)
+{
+	void *verify;
+	ssize_t n;
+	size_t sector = bd->sector_size;
+	int ret = 0;
+
+	ret = fsync(bd->dev_fd);
+	if (ret)
+		return ret;
+
+	off_t aligned_off = off & ~(sector - 1);
+	size_t head = off - aligned_off;
+	size_t aligned_len = ((head + len + sector - 1) / sector) * sector;
+
+	if (posix_memalign(&verify, sector, aligned_len))
+		return -ENOMEM;
+	memset(verify, 0, aligned_len);
+
+	n = exfat_read(bd->verify_fd, verify, aligned_len, aligned_off);
+	if (n != (ssize_t)aligned_len) {
+		exfat_debug("%s verify read failed (off=%llu, len=%zu)\n",
+					what, (unsigned long long)aligned_off,
+					aligned_len);
+		ret = -EIO;
+	}
+
+	if (memcmp(buf, (unsigned char *)verify + head, len) != 0) {
+		exfat_debug("%s verify mismatch (off=%llu)\n",
+					what, (unsigned long long)off);
+		ret = -EIO;
+	}
+
+	free(verify);
+	return ret;
+}
+
 int exfat_read_sector(struct exfat_blk_dev *bd, void *buf, unsigned int sec_off)
 {
 	int ret;
@@ -715,7 +767,8 @@ int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
 }
 
 int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
-		unsigned int checksum, bool is_backup)
+		struct exfat_user_input *ui, unsigned int checksum,
+		bool is_backup)
 {
 	__le32 *checksum_buf;
 	int ret = 0;
@@ -736,6 +789,17 @@ int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
 	if (ret) {
 		exfat_err("checksum sector write failed\n");
 		goto free;
+	}
+
+	if (ui && ui->verify) {
+		ret = exfat_check_written_data(bd,
+				checksum_buf, bd->sector_size,
+				sec_idx * bd->sector_size,
+				"checksum sector");
+		if (ret) {
+			exfat_err("checksum sector verification failed (read-back mismatch)\n");
+			goto free;
+		}
 	}
 
 free:
@@ -775,7 +839,8 @@ free_ppbr:
 	return ret;
 }
 
-static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
+static int exfat_update_boot_checksum(struct exfat_blk_dev *bd,
+	struct exfat_user_input *ui, bool is_backup)
 {
 	unsigned int checksum = 0;
 	int ret, sec_idx, backup_sec_idx = 0;
@@ -807,7 +872,7 @@ static int exfat_update_boot_checksum(struct exfat_blk_dev *bd, bool is_backup)
 			&checksum);
 	}
 
-	ret = exfat_write_checksum_sector(bd, checksum, is_backup);
+	ret = exfat_write_checksum_sector(bd, ui, checksum, is_backup);
 
 free_buf:
 	free(buf);
@@ -861,13 +926,13 @@ int exfat_set_volume_serial(struct exfat_blk_dev *bd,
 		goto free_ppbr;
 	}
 
-	ret = exfat_update_boot_checksum(bd, 0);
+	ret = exfat_update_boot_checksum(bd, ui, 0);
 	if (ret < 0) {
 		exfat_err("main checksum update failed\n");
 		goto free_ppbr;
 	}
 
-	ret = exfat_update_boot_checksum(bd, 1);
+	ret = exfat_update_boot_checksum(bd, ui, 1);
 	if (ret < 0)
 		exfat_err("backup checksum update failed\n");
 free_ppbr:

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -423,8 +423,10 @@ char *exfat_conv_volume_label(struct exfat_dentry *vol_entry)
 	__le16 disk_label[VOLUME_LABEL_MAX_LEN];
 
 	volume_label = malloc(VOLUME_LABEL_BUFFER_SIZE);
-	if (!volume_label)
+	if (!volume_label) {
+		exfat_err("Cannot allocate volume_label: out of memory\n");
 		return NULL;
+	}
 
 	memcpy(disk_label, vol_entry->vol_label, sizeof(disk_label));
 	memset(volume_label, 0, VOLUME_LABEL_BUFFER_SIZE);
@@ -776,8 +778,10 @@ int exfat_write_checksum_sector(struct exfat_blk_dev *bd,
 	unsigned int sec_idx = CHECKSUM_SEC_IDX;
 
 	checksum_buf = malloc(bd->sector_size);
-	if (!checksum_buf)
+	if (!checksum_buf) {
+		exfat_err("Cannot allocate checksum_buf: out of memory\n");
 		return -1;
+	}
 
 	if (is_backup)
 		sec_idx += BACKUP_BOOT_SEC_IDX;

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -137,6 +137,7 @@ void init_user_input(struct exfat_user_input *ui)
 	memset(ui, 0, sizeof(struct exfat_user_input));
 	ui->writeable = true;
 	ui->quick = true;
+	ui->discard = true;
 }
 
 int exfat_get_blk_dev_info(struct exfat_user_input *ui,
@@ -165,6 +166,8 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 	if (fstat(fd, &st) == 0 && S_ISBLK(st.st_mode)) {
 		char pathname[sizeof("/sys/dev/block/4294967295:4294967295/start")];
 		FILE *fp;
+
+		bd->isblk = true;
 
 		snprintf(pathname, sizeof(pathname), "/sys/dev/block/%u:%u/start",
 			major(st.st_rdev), minor(st.st_rdev));
@@ -248,6 +251,15 @@ ssize_t exfat_write_zero(int fd, size_t size, off_t offset)
 		size -= iter_size;
 	}
 
+	return 0;
+}
+
+int exfat_discard_blocks(int fd, uint64_t start, uint64_t len)
+{
+	uint64_t range[2] = { start, len };
+
+	if (ioctl(fd, BLKDISCARD, &range) < 0)
+		return errno;
 	return 0;
 }
 

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -16,6 +16,8 @@ mkfs.exfat \- create an exFAT filesystem
 ] [
 .B \-f
 ] [
+.B \-C
+] [
 .B \-h
 ] [
 .B \-L
@@ -103,6 +105,16 @@ _
 .BR \-f ", " \-\-full\-format
 Performs a full format.
 This zeros the entire disk device while creating the exFAT filesystem.
+.TP
+.BR \-C ", " \-\-verify\-written
+Verify filesystem metadata by reading it back after writing.
+This option performs read-back verification of critical exFAT metadata
+(boot record, FAT, allocation bitmap, upcase table, and root directory)
+after each formatting stage.
+It is useful for detecting broken storage devices or devices that falsely
+report successful writes without actually persisting data.
+This option may slightly degrade formatting performance and is therefore
+disabled by default.
 .TP
 .BR \-h ", " \-\-help
 Prints the help and exit.

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -105,6 +105,10 @@ _
 .BR \-f ", " \-\-full\-format
 Performs a full format.
 This zeros the entire disk device while creating the exFAT filesystem.
+.TE
+.TP
+.BR \-K ", " \-\-no\-discard
+Do not attempt to discard blocks.
 .TP
 .BR \-C ", " \-\-verify\-written
 Verify filesystem metadata by reading it back after writing.

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -521,6 +521,7 @@ static void usage(void)
 		"\t     --pack-bitmap                                     Move bitmap into FAT segment\n"
 		"\t-f | --full-format                                     Full format\n"
 		"\t-C | --check-written                                   Verify written filesystem metadata by read-back\n"
+		"\t-K | --no-discard                                      Do not discard blocks\n"
 		"\t-V | --version                                         Show version\n"
 		"\t-q | --quiet                                           Print only errors\n"
 		"\t-v | --verbose                                         Print debug\n"
@@ -541,6 +542,7 @@ static const struct option opts[] = {
 	{"pack-bitmap",		no_argument,		NULL,	PACK_BITMAP },
 	{"full-format",		no_argument,		NULL,	'f' },
 	{"check-written",	no_argument,		NULL,	'C' },
+	{"no-discard",		no_argument,		NULL,	'K' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"quiet",		no_argument,		NULL,	'q' },
 	{"verbose",		no_argument,		NULL,	'v' },
@@ -666,6 +668,56 @@ static int exfat_zero_out_disk(struct exfat_blk_dev *bd,
 	return 0;
 }
 
+static void exfat_discard_dev(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui)
+{
+	uint64_t offset = 0;
+	uint64_t tmp_step;
+	int err;
+	/* Discard the device 2G at a time */
+	const uint64_t step = 2ULL << 30;
+	const uint64_t count = bd->num_sectors * bd->sector_size;
+
+	if (!ui->discard || !bd->isblk) {
+		exfat_debug("no-discard requested or the device is a file\n");
+		return;
+	}
+
+	/*
+	 * The block discarding happens in smaller batches so it can be
+	 * interrupted prematurely
+	 */
+	while (offset < count) {
+		tmp_step = count - offset;
+		if (step < tmp_step)
+			tmp_step = step;
+
+		err = exfat_discard_blocks(bd->dev_fd, offset, tmp_step);
+		/*
+		 * We intentionally ignore errors from the discard ioctl. It is
+		 * not necessary for the mkfs functionality but just an
+		 * optimization. However we should stop on error.
+		 */
+		if (err == 0) {
+			if (offset == 0) {
+				exfat_info("Discarding blocks: ");
+				exfat_debug("BLKDISCARD: ");
+			}
+			exfat_debug("%"PRIu64"-%"PRIu64" ", offset, offset + tmp_step);
+			fflush(stdout);
+		} else {
+			exfat_debug("BLKDISCARD: %s\n", strerror(err));
+			if (offset > 0)
+				exfat_info("\n");
+			return;
+		}
+
+		offset += tmp_step;
+	}
+	if (offset > 0)
+		exfat_info("done\n");
+}
+
 static int make_exfat(struct exfat_blk_dev *bd, struct exfat_user_input *ui)
 {
 	int ret;
@@ -753,7 +805,7 @@ int main(int argc, char *argv[])
 		exfat_err("failed to init locale/codeset\n");
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fCVqvh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fCKVqvh", opts, NULL)) != EOF)
 		switch (c) {
 		/*
 		 * Make 'n' option fallthrough to 'L' option for for backward
@@ -825,6 +877,9 @@ int main(int argc, char *argv[])
 		case 'C':
 			ui.verify = true;
 			break;
+		case 'K':
+			ui.discard = false;
+			break;
 		case 'V':
 			version_only = true;
 			break;
@@ -869,6 +924,12 @@ int main(int argc, char *argv[])
 	if (ret)
 		goto close;
 
+	exfat_discard_dev(&bd, &ui);
+	/*
+	 * Zeroing out still needs to be conducted as per JESD84-B51 6.6.9:
+	 * "content of an explicitly erased memory range shall be ‘0’ or ‘1’
+	 * depending on different memory technology,"
+	 */
 	ret = exfat_zero_out_disk(&bd, &ui);
 	if (ret)
 		goto close;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -157,8 +157,10 @@ static int exfat_write_extended_boot_sectors(struct exfat_blk_dev *bd,
 	unsigned int sec_idx = EXBOOT_SEC_IDX;
 
 	peb = malloc(bd->sector_size);
-	if (!peb)
+	if (!peb) {
+		exfat_err("Cannot allocate peb: out of memory\n");
 		return -1;
+	}
 
 	if (is_backup)
 		sec_idx += BACKUP_BOOT_SEC_IDX;
@@ -398,8 +400,10 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd,
 	int ret = 0;
 
 	bitmap = malloc(finfo.bitmap_byte_len);
-	if (!bitmap)
+	if (!bitmap) {
+		exfat_err("Cannot allocate bitmap: out of memory\n");
 		return -1;
+	}
 
 	full_bytes = finfo.used_clu_cnt / 8;
 	rem_bits = finfo.used_clu_cnt % 8;
@@ -884,5 +888,5 @@ out:
 		exfat_info("\nexFAT format complete!\n");
 	else
 		exfat_err("\nexFAT format fail!\n");
-	return ret;
+	return ret ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -127,6 +127,17 @@ static int exfat_write_boot_sector(struct exfat_blk_dev *bd,
 		goto free_ppbr;
 	}
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				ppbr, bd->sector_size,
+				sec_idx * bd->sector_size,
+				"boot sector");
+		if (ret) {
+			exfat_err("boot sector verification failed (read-back mismatch)\n");
+			goto free_ppbr;
+		}
+	}
+
 	boot_calc_checksum((unsigned char *)ppbr, bd->sector_size,
 		true, checksum);
 
@@ -136,7 +147,8 @@ free_ppbr:
 }
 
 static int exfat_write_extended_boot_sectors(struct exfat_blk_dev *bd,
-		unsigned int *checksum, bool is_backup)
+		struct exfat_user_input *ui, unsigned int *checksum,
+		bool is_backup)
 {
 	char *peb;
 	__le16 *peb_signature;
@@ -161,6 +173,17 @@ static int exfat_write_extended_boot_sectors(struct exfat_blk_dev *bd,
 			goto free_peb;
 		}
 
+		if (ui->verify) {
+			ret = exfat_check_written_data(bd,
+					peb, bd->sector_size,
+					(sec_idx - 1) * bd->sector_size,
+					"extended boot sector");
+			if (ret) {
+				exfat_err("extended boot sector verification failed (read-back mismatch)\n");
+				goto free_peb;
+			}
+		}
+
 		boot_calc_checksum((unsigned char *) peb, bd->sector_size,
 			false, checksum);
 	}
@@ -171,7 +194,8 @@ free_peb:
 }
 
 static int exfat_write_oem_sector(struct exfat_blk_dev *bd,
-		unsigned int *checksum, bool is_backup)
+		struct exfat_user_input *ui, unsigned int *checksum,
+		bool is_backup)
 {
 	char *oem;
 	int ret = 0;
@@ -191,6 +215,17 @@ static int exfat_write_oem_sector(struct exfat_blk_dev *bd,
 		goto free_oem;
 	}
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				oem, bd->sector_size,
+				sec_idx * bd->sector_size,
+				"oem sector");
+		if (ret) {
+			exfat_err("oem sector verification failed (read-back mismatch)\n");
+			goto free_oem;
+		}
+	}
+
 	boot_calc_checksum((unsigned char *)oem, bd->sector_size, false,
 		checksum);
 
@@ -200,6 +235,17 @@ static int exfat_write_oem_sector(struct exfat_blk_dev *bd,
 		exfat_err("reserved sector write failed\n");
 		ret = -1;
 		goto free_oem;
+	}
+
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				oem, bd->sector_size,
+				(sec_idx + 1) * bd->sector_size,
+				"reserved sector");
+		if (ret) {
+			exfat_err("reserved sector verification failed (read-back mismatch)\n");
+			goto free_oem;
+		}
 	}
 
 	boot_calc_checksum((unsigned char *)oem, bd->sector_size, false,
@@ -219,18 +265,18 @@ static int exfat_create_volume_boot_record(struct exfat_blk_dev *bd,
 	ret = exfat_write_boot_sector(bd, ui, &checksum, is_backup);
 	if (ret)
 		return ret;
-	ret = exfat_write_extended_boot_sectors(bd, &checksum, is_backup);
+	ret = exfat_write_extended_boot_sectors(bd, ui, &checksum, is_backup);
 	if (ret)
 		return ret;
-	ret = exfat_write_oem_sector(bd, &checksum, is_backup);
+	ret = exfat_write_oem_sector(bd, ui, &checksum, is_backup);
 	if (ret)
 		return ret;
 
-	return exfat_write_checksum_sector(bd, checksum, is_backup);
+	return exfat_write_checksum_sector(bd, ui, checksum, is_backup);
 }
 
-static int write_fat_entry(int fd, __le32 clu,
-		unsigned long long offset)
+static int write_fat_entry(struct exfat_user_input *ui, int fd,
+		__le32 clu, unsigned long long offset)
 {
 	int nbyte;
 	off_t fat_entry_offset = finfo.fat_byte_off + (offset * sizeof(__le32));
@@ -240,6 +286,11 @@ static int write_fat_entry(int fd, __le32 clu,
 		exfat_err("write failed, offset : %llu, clu : %x\n",
 			offset, clu);
 		return -1;
+	}
+
+	if (ui->verify) {
+		memcpy(ui->fat_table_buff + offset * sizeof(__le32),
+			(__u8 *)&clu, sizeof(__le32));
 	}
 
 	return 0;
@@ -254,12 +305,12 @@ static int write_fat_entries(struct exfat_user_input *ui, int fd,
 	count = clu + round_up(length, ui->cluster_size) / ui->cluster_size;
 
 	for (; clu < count - 1; clu++) {
-		ret = write_fat_entry(fd, cpu_to_le32(clu + 1), clu);
+		ret = write_fat_entry(ui, fd, cpu_to_le32(clu + 1), clu);
 		if (ret)
 			return ret;
 	}
 
-	ret = write_fat_entry(fd, cpu_to_le32(EXFAT_EOF_CLUSTER), clu);
+	ret = write_fat_entry(ui, fd, cpu_to_le32(EXFAT_EOF_CLUSTER), clu);
 	if (ret)
 		return ret;
 
@@ -270,48 +321,81 @@ static int exfat_create_fat_table(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
 	int ret, clu;
+	unsigned int fat_table_entries = 0;
+
+	if (ui->verify) {
+		fat_table_entries =
+			EXFAT_FIRST_CLUSTER +
+			DIV_ROUND_UP(finfo.bitmap_byte_len, ui->cluster_size) +
+			DIV_ROUND_UP(finfo.ut_byte_len, ui->cluster_size) +
+			DIV_ROUND_UP(finfo.root_byte_len, ui->cluster_size);
+
+		ui->fat_table_buff = calloc(fat_table_entries, sizeof(__le32));
+		if (!ui->fat_table_buff)
+			return -ENOMEM;
+	}
 
 	/* fat entry 0 should be media type field(0xF8) */
-	ret = write_fat_entry(bd->dev_fd, cpu_to_le32(0xfffffff8), 0);
+	ret = write_fat_entry(ui, bd->dev_fd, cpu_to_le32(0xfffffff8), 0);
 	if (ret) {
 		exfat_err("fat 0 entry write failed\n");
-		return ret;
+		goto free_fat_table_buff;
 	}
 
 	/* fat entry 1 is historical precedence(0xFFFFFFFF) */
-	ret = write_fat_entry(bd->dev_fd, cpu_to_le32(0xffffffff), 1);
+	ret = write_fat_entry(ui, bd->dev_fd, cpu_to_le32(0xffffffff), 1);
 	if (ret) {
 		exfat_err("fat 1 entry write failed\n");
-		return ret;
+		goto free_fat_table_buff;
 	}
 
 	/* write bitmap entries */
 	clu = write_fat_entries(ui, bd->dev_fd, EXFAT_FIRST_CLUSTER,
 		finfo.bitmap_byte_len);
-	if (clu < 0)
-		return ret;
+	if (clu < 0) {
+		ret = clu;
+		goto free_fat_table_buff;
+	}
 
 	/* write upcase table entries */
 	clu = write_fat_entries(ui, bd->dev_fd, clu + 1, finfo.ut_byte_len);
-	if (clu < 0)
-		return ret;
+	if (clu < 0) {
+		ret = clu;
+		goto free_fat_table_buff;
+	}
 
 	/* write root directory entries */
 	clu = write_fat_entries(ui, bd->dev_fd, clu + 1, finfo.root_byte_len);
-	if (clu < 0)
-		return ret;
+	if (clu < 0) {
+		ret = clu;
+		goto free_fat_table_buff;
+	}
 
 	finfo.used_clu_cnt = clu + 1 - EXFAT_FIRST_CLUSTER;
 	exfat_debug("Total used cluster count : %d\n", finfo.used_clu_cnt);
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				ui->fat_table_buff, fat_table_entries * sizeof(__le32),
+				finfo.fat_byte_off,
+				"fat table");
+		if (ret)
+			exfat_err("fat table verification failed (read-back mismatch)\n");
+	}
+
+free_fat_table_buff:
+	if (ui->verify)
+		free(ui->fat_table_buff);
 	return ret;
 }
 
-static int exfat_create_bitmap(struct exfat_blk_dev *bd)
+static int exfat_create_bitmap(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui)
 {
 	char *bitmap;
 	unsigned int full_bytes, rem_bits, zero_offset;
 	unsigned int nbytes;
+	int ret = 0;
 
 	bitmap = malloc(finfo.bitmap_byte_len);
 	if (!bitmap)
@@ -338,6 +422,18 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd)
 			nbytes, finfo.bitmap_byte_len);
 		free(bitmap);
 		return -1;
+	}
+
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				bitmap, finfo.bitmap_byte_len,
+				finfo.bitmap_byte_off,
+				"bitmap");
+		if (ret) {
+			exfat_err("bitmap verification failed (read-back mismatch)\n");
+			free(bitmap);
+			return ret;
+		}
 	}
 
 	free(bitmap);
@@ -396,6 +492,17 @@ static int exfat_create_root_dir(struct exfat_blk_dev *bd,
 		return -1;
 	}
 
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				ed, dentries_len,
+				finfo.root_byte_off,
+				"root directory");
+		if (ret) {
+			exfat_err("root directory verification failed (read-back mismatch)\n");
+			return ret;
+		}
+
+	}
 	return 0;
 }
 
@@ -409,6 +516,7 @@ static void usage(void)
 		"\t-b | --boundary-align=size(or suffixed by 'K' or 'M')  Specify boundary alignment\n"
 		"\t     --pack-bitmap                                     Move bitmap into FAT segment\n"
 		"\t-f | --full-format                                     Full format\n"
+		"\t-C | --check-written                                   Verify written filesystem metadata by read-back\n"
 		"\t-V | --version                                         Show version\n"
 		"\t-q | --quiet                                           Print only errors\n"
 		"\t-v | --verbose                                         Print debug\n"
@@ -428,6 +536,7 @@ static const struct option opts[] = {
 	{"boundary-align",	required_argument,	NULL,	'b' },
 	{"pack-bitmap",		no_argument,		NULL,	PACK_BITMAP },
 	{"full-format",		no_argument,		NULL,	'f' },
+	{"check-written",	no_argument,		NULL,	'C' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"quiet",		no_argument,		NULL,	'q' },
 	{"verbose",		no_argument,		NULL,	'v' },
@@ -580,13 +689,13 @@ static int make_exfat(struct exfat_blk_dev *bd, struct exfat_user_input *ui)
 		return ret;
 
 	exfat_info("Allocation bitmap creation: ");
-	ret = exfat_create_bitmap(bd);
+	ret = exfat_create_bitmap(bd, ui);
 	exfat_info("%s\n", ret ? "failed" : "done");
 	if (ret)
 		return ret;
 
 	exfat_info("Upcase table creation: ");
-	ret = exfat_create_upcase_table(bd);
+	ret = exfat_create_upcase_table(bd, ui);
 	exfat_info("%s\n", ret ? "failed" : "done");
 	if (ret)
 		return ret;
@@ -640,7 +749,7 @@ int main(int argc, char *argv[])
 		exfat_err("failed to init locale/codeset\n");
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fVqvh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fCVqvh", opts, NULL)) != EOF)
 		switch (c) {
 		/*
 		 * Make 'n' option fallthrough to 'L' option for for backward
@@ -709,6 +818,9 @@ int main(int argc, char *argv[])
 		case 'f':
 			ui.quick = false;
 			break;
+		case 'C':
+			ui.verify = true;
+			break;
 		case 'V':
 			version_only = true;
 			break;
@@ -765,6 +877,8 @@ int main(int argc, char *argv[])
 	ret = fsync(bd.dev_fd);
 close:
 	close(bd.dev_fd);
+	if (ui.verify)
+		close(bd.verify_fd);
 out:
 	if (!ret)
 		exfat_info("\nexFAT format complete!\n");

--- a/mkfs/mkfs.h
+++ b/mkfs/mkfs.h
@@ -27,6 +27,6 @@ struct exfat_mkfs_info {
 
 extern struct exfat_mkfs_info finfo;
 
-int exfat_create_upcase_table(struct exfat_blk_dev *bd);
+int exfat_create_upcase_table(struct exfat_blk_dev *bd, struct exfat_user_input *ui);
 
 #endif /* !_MKFS_H */

--- a/mkfs/upcase.c
+++ b/mkfs/upcase.c
@@ -13,14 +13,28 @@
 #include "mkfs.h"
 #include "upcase_table.h"
 
-int exfat_create_upcase_table(struct exfat_blk_dev *bd)
+int exfat_create_upcase_table(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui)
 {
 	int nbytes;
+	int ret;
 
 	nbytes = pwrite(bd->dev_fd, default_upcase_table,
 			EXFAT_UPCASE_TABLE_SIZE, finfo.ut_byte_off);
 	if (nbytes != EXFAT_UPCASE_TABLE_SIZE)
 		return -1;
+
+	if (ui->verify) {
+		ret = exfat_check_written_data(bd,
+				default_upcase_table,
+				EXFAT_UPCASE_TABLE_SIZE,
+				finfo.ut_byte_off,
+				"upcase table");
+		if (ret) {
+			exfat_err("upcase table verification failed (read-back mismatch)\n");
+			return ret;
+		}
+	}
 
 	return 0;
 }

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -152,5 +152,5 @@ close_fd_out:
 	if (exfat)
 		exfat_free_exfat(exfat);
 out:
-	return ret;
+	return ret ? EXIT_FAILURE : EXIT_SUCCESS;
 }


### PR DESCRIPTION
Discard blocks by default to speed up disk writes ops and potentially help wear leveling on flash-memory-backed devices such as SSDs and MMC cards. Also useful for device-managed SMR HDD.

Most mkfs utils discard blocks at mkfs time by default. As such, it only makes sense for mkfs.exfat to do the same.

The code ported from mkfs.xfs.