### PR TITLE
[v2] mkfs.exfat: discard blocks prior to write outs

### DIFF
--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -76,6 +76,7 @@ struct exfat_blk_dev {
 	unsigned long long num_sectors;
 	unsigned int num_clusters;
 	unsigned int cluster_size;
+	bool isblk;
 };
 
 struct exfat_user_input {
@@ -88,6 +89,7 @@ struct exfat_user_input {
 	bool pack_bitmap;
 	bool quick;
 	bool verify;
+	bool discard;
 	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
 	int volume_label_len;
 	unsigned int volume_serial;
@@ -158,6 +160,7 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 ssize_t exfat_read(int fd, void *buf, size_t size, off_t offset);
 ssize_t exfat_write(int fd, void *buf, size_t size, off_t offset);
 ssize_t exfat_write_zero(int fd, size_t size, off_t offset);
+int exfat_discard_blocks(int fd, uint64_t start, uint64_t len);
 
 size_t exfat_utf16_len(const __le16 *str, size_t max_size);
 ssize_t exfat_utf16_enc(const char *in_str, __u16 *out_str, size_t out_size);

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -137,6 +137,7 @@ void init_user_input(struct exfat_user_input *ui)
 	memset(ui, 0, sizeof(struct exfat_user_input));
 	ui->writeable = true;
 	ui->quick = true;
+	ui->discard = true;
 }
 
 int exfat_get_blk_dev_info(struct exfat_user_input *ui,
@@ -165,6 +166,8 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 	if (fstat(fd, &st) == 0 && S_ISBLK(st.st_mode)) {
 		char pathname[sizeof("/sys/dev/block/4294967295:4294967295/start")];
 		FILE *fp;
+
+		bd->isblk = true;
 
 		snprintf(pathname, sizeof(pathname), "/sys/dev/block/%u:%u/start",
 			major(st.st_rdev), minor(st.st_rdev));
@@ -248,6 +251,15 @@ ssize_t exfat_write_zero(int fd, size_t size, off_t offset)
 		size -= iter_size;
 	}
 
+	return 0;
+}
+
+int exfat_discard_blocks(int fd, uint64_t start, uint64_t len)
+{
+	uint64_t range[2] = { start, len };
+
+	if (ioctl(fd, BLKDISCARD, &range) < 0)
+		return errno;
 	return 0;
 }
 

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -105,6 +105,10 @@ _
 .BR \-f ", " \-\-full\-format
 Performs a full format.
 This zeros the entire disk device while creating the exFAT filesystem.
+.TE
+.TP
+.BR \-K ", " \-\-no\-discard
+Do not attempt to discard blocks.
 .TP
 .BR \-C ", " \-\-verify\-written
 Verify filesystem metadata by reading it back after writing.

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -521,6 +521,7 @@ static void usage(void)
 		"\t     --pack-bitmap                                     Move bitmap into FAT segment\n"
 		"\t-f | --full-format                                     Full format\n"
 		"\t-C | --check-written                                   Verify written filesystem metadata by read-back\n"
+		"\t-K | --no-discard                                      Do not discard blocks\n"
 		"\t-V | --version                                         Show version\n"
 		"\t-q | --quiet                                           Print only errors\n"
 		"\t-v | --verbose                                         Print debug\n"
@@ -541,6 +542,7 @@ static const struct option opts[] = {
 	{"pack-bitmap",		no_argument,		NULL,	PACK_BITMAP },
 	{"full-format",		no_argument,		NULL,	'f' },
 	{"check-written",	no_argument,		NULL,	'C' },
+	{"no-discard",		no_argument,		NULL,	'K' },
 	{"version",		no_argument,		NULL,	'V' },
 	{"quiet",		no_argument,		NULL,	'q' },
 	{"verbose",		no_argument,		NULL,	'v' },
@@ -666,6 +668,56 @@ static int exfat_zero_out_disk(struct exfat_blk_dev *bd,
 	return 0;
 }
 
+static void exfat_discard_dev(struct exfat_blk_dev *bd,
+		struct exfat_user_input *ui)
+{
+	uint64_t offset = 0;
+	uint64_t tmp_step;
+	int err;
+	/* Discard the device 2G at a time */
+	const uint64_t step = 2ULL << 30;
+	const uint64_t count = bd->num_sectors * bd->sector_size;
+
+	if (!ui->discard || !bd->isblk) {
+		exfat_debug("no-discard requested or the device is a file\n");
+		return;
+	}
+
+	/*
+	 * The block discarding happens in smaller batches so it can be
+	 * interrupted prematurely
+	 */
+	while (offset < count) {
+		tmp_step = count - offset;
+		if (step < tmp_step)
+			tmp_step = step;
+
+		err = exfat_discard_blocks(bd->dev_fd, offset, tmp_step);
+		/*
+		 * We intentionally ignore errors from the discard ioctl. It is
+		 * not necessary for the mkfs functionality but just an
+		 * optimization. However we should stop on error.
+		 */
+		if (err == 0) {
+			if (offset == 0) {
+				exfat_info("Discarding blocks: ");
+				exfat_debug("BLKDISCARD: ");
+			}
+			exfat_debug("%"PRIu64"-%"PRIu64" ", offset, offset + tmp_step);
+			fflush(stdout);
+		} else {
+			exfat_debug("BLKDISCARD: %s\n", strerror(err));
+			if (offset > 0)
+				exfat_info("\n");
+			return;
+		}
+
+		offset += tmp_step;
+	}
+	if (offset > 0)
+		exfat_info("done\n");
+}
+
 static int make_exfat(struct exfat_blk_dev *bd, struct exfat_user_input *ui)
 {
 	int ret;
@@ -753,7 +805,7 @@ int main(int argc, char *argv[])
 		exfat_err("failed to init locale/codeset\n");
 
 	opterr = 0;
-	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fCVqvh", opts, NULL)) != EOF)
+	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:fCKVqvh", opts, NULL)) != EOF)
 		switch (c) {
 		/*
 		 * Make 'n' option fallthrough to 'L' option for for backward
@@ -825,6 +877,9 @@ int main(int argc, char *argv[])
 		case 'C':
 			ui.verify = true;
 			break;
+		case 'K':
+			ui.discard = false;
+			break;
 		case 'V':
 			version_only = true;
 			break;
@@ -869,6 +924,12 @@ int main(int argc, char *argv[])
 	if (ret)
 		goto close;
 
+	exfat_discard_dev(&bd, &ui);
+	/*
+	 * Zeroing out still needs to be conducted as per JESD84-B51 6.6.9:
+	 * "content of an explicitly erased memory range shall be ‘0’ or ‘1’
+	 * depending on different memory technology,"
+	 */
 	ret = exfat_zero_out_disk(&bd, &ui);
 	if (ret)
 		goto close;


### PR DESCRIPTION
Discard blocks by default to speed up disk writes ops and potentially help wear leveling on flash-memory-backed devices such as SSDs and MMC cards. Also useful for device-managed SMR HDD.

Most mkfs utils discard blocks at mkfs time by default. As such, it only makes sense for mkfs.exfat to do the same.

The code ported from mkfs.xfs.