### PR TITLE
exfatprogs: release 1.3.2 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,25 @@
+exfatprogs 1.3.2 - release 2026-03-09
+===================================
+
+NEW FEATURES :
+ * fsck.exfat: add an option to show a progress bar
+   while checking a filesystem.
+
+CHANGES :
+ * mkfs.exfat: discard blocks prior to write outs by
+   default.
+ * mkfs.exfat: add a read-after-write verification for
+   the volume boot record.
+ * exfatprogs: adjust utility exit codes and add log
+   messages for malloc() failures.
+
+BUG FIXES :
+ * dump.exfat: handle paths including '.', '..', and
+   repeated '/'.
+ * fsck.exfat: convert 0x80 entries into deleted file
+   entries to avoid bogus dentry errors.
+ * fsck.exfat: fix an uninitialized variable warning.
+
 exfatprogs 1.3.1 - released 2025-12-15
 =====================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,6 +5,6 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.3.1"
+#define EXFAT_PROGS_VERSION "1.3.2"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
NEW FEATURES :
 * fsck.exfat: add an option to show a progress bar while checking a filesystem.

CHANGES :
 * mkfs.exfat: discard blocks prior to write outs by default.
 * mkfs.exfat: add a read-after-write verification for the volume boot record.
 * exfatprogs: adjust utility exit codes and add log messages for malloc() failures.

BUG FIXES :
 * dump.exfat: handle paths including '.', '..', and repeated '/'.
 * fsck.exfat: convert 0x80 entries into deleted file entries to avoid bogus dentry errors.
 * fsck.exfat: fix an uninitialized variable warning.