### PR TITLE
fsck: fix sign extension and progress bar overflowProgree bar fix

### DIFF
--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1929,6 +1929,8 @@ int main(int argc, char * const argv[])
 	}
 	if (exfat_fsck.options & FSCK_OPTS_REPAIR_WRITE)
 		exfat_mark_volume_dirty(exfat_fsck.exfat, false);
+	if (exfat_fsck.options & FSCK_OPTS_PROGRESS_BAR)
+		progress_finish(&exfat_fsck.progress_bar);
 
 out:
 	exfat_show_info(&exfat_fsck, ui.ei.dev_name);

--- a/include/exfat_fs.h
+++ b/include/exfat_fs.h
@@ -38,9 +38,9 @@ struct exfat {
 	clus_t			clus_count;
 	unsigned int		clus_size;
 	unsigned int		sect_size;
-	char			*disk_bitmap;
-	char			*alloc_bitmap;
-	char			*ohead_bitmap;
+	unsigned char		*disk_bitmap;
+	unsigned char		*alloc_bitmap;
+	unsigned char		*ohead_bitmap;
 	clus_t			disk_bitmap_clus;
 	unsigned int		disk_bitmap_size;
 	__u16			*upcase_table;

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -122,31 +122,31 @@ typedef __u32	bitmap_t;
 #define BITMAP_CLEAR(bmap, bit)	\
 	(((bitmap_t *)(bmap))[BIT_ENTRY(bit)] &= ~BIT_MASK(bit))
 
-static inline bool exfat_bitmap_get(char *bmap, clus_t c)
+static inline bool exfat_bitmap_get(unsigned char *bmap, clus_t c)
 {
 	clus_t cc = c - EXFAT_FIRST_CLUSTER;
 
 	return BITMAP_GET(bmap, cc);
 }
 
-static inline void exfat_bitmap_set(char *bmap, clus_t c)
+static inline void exfat_bitmap_set(unsigned char *bmap, clus_t c)
 {
 	clus_t cc = c - EXFAT_FIRST_CLUSTER;
 
 	BITMAP_SET(bmap, cc);
 }
 
-static inline void exfat_bitmap_clear(char *bmap, clus_t c)
+static inline void exfat_bitmap_clear(unsigned char *bmap, clus_t c)
 {
 	clus_t cc = c - EXFAT_FIRST_CLUSTER;
 	(((bitmap_t *)(bmap))[BIT_ENTRY(cc)] &= ~BIT_MASK(cc));
 }
 
-void exfat_bitmap_set_range(struct exfat *exfat, char *bitmap,
+void exfat_bitmap_set_range(struct exfat *exfat, unsigned char *bitmap,
 			    clus_t start_clus, clus_t count);
-int exfat_bitmap_find_zero(struct exfat *exfat, char *bmap,
+int exfat_bitmap_find_zero(struct exfat *exfat, unsigned char *bmap,
 			   clus_t start_clu, clus_t *next);
-int exfat_bitmap_find_one(struct exfat *exfat, char *bmap,
+int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 			  clus_t start_clu, clus_t *next);
 
 void show_version(void);

--- a/include/utils.h
+++ b/include/utils.h
@@ -24,4 +24,5 @@ struct progress_bar {
 
 void progress_init(struct progress_bar *p, uint32_t start, uint32_t stop, uint32_t res);
 void progress_update(struct progress_bar *p, uint32_t current);
+void progress_finish(struct progress_bar *p);
 #endif

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -28,7 +28,7 @@
 
 unsigned int print_level  = EXFAT_INFO;
 
-void exfat_bitmap_set_range(struct exfat *exfat, char *bitmap,
+void exfat_bitmap_set_range(struct exfat *exfat, unsigned char *bitmap,
 			    clus_t start_clus, clus_t count)
 {
 	clus_t clus;
@@ -44,7 +44,7 @@ void exfat_bitmap_set_range(struct exfat *exfat, char *bitmap,
 	}
 }
 
-static int exfat_bitmap_find_bit(struct exfat *exfat, char *bmap,
+static int exfat_bitmap_find_bit(struct exfat *exfat, unsigned char *bmap,
 				 clus_t start_clu, clus_t *next,
 				 int bit)
 {
@@ -62,14 +62,14 @@ static int exfat_bitmap_find_bit(struct exfat *exfat, char *bmap,
 	return 1;
 }
 
-int exfat_bitmap_find_zero(struct exfat *exfat, char *bmap,
+int exfat_bitmap_find_zero(struct exfat *exfat, unsigned char *bmap,
 			   clus_t start_clu, clus_t *next)
 {
 	return exfat_bitmap_find_bit(exfat, bmap,
 				     start_clu, next, 0);
 }
 
-int exfat_bitmap_find_one(struct exfat *exfat, char *bmap,
+int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 			  clus_t start_clu, clus_t *next)
 {
 	return exfat_bitmap_find_bit(exfat, bmap,

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -50,17 +50,29 @@ void progress_update(struct progress_bar *p, uint32_t update)
 #endif
 
 	p->current += update;
-	if (p->current != p->stop) {
-		if ((p->current - p->start) % p->resolution)
-			return;
+	if ((p->current - p->start) % p->resolution)
+		return;
+
+	if (p->current >= p->stop) {
+#ifdef PROG_CALC_FLOAT
+		printf("99.99 percent completed (processed: %u clusters)\r", p->current);
+#else
+		printf("99 percent completed (processed: %u clusters)\r", p->current);
+#endif
+	} else {
 #ifdef PROG_CALC_FLOAT
 		percent = p->unit * p->current;
-		printf("%6.2f percent completed\r", percent);
+		printf("%6.2f percent completed (processed: %u clusters)\r", percent, p->current);
 #else
 		percent = (p->current * 100) / p->total;
-		printf("%3u percent completed\r", percent);
+		printf("%3u percent completed (processed: %u clusters)\r", percent, p->current);
 #endif
-	} else
-		printf("100.00 percent completed\n");
+	}
+	fflush(stdout);
+}
+
+void progress_finish(struct progress_bar *p)
+{
+	printf("100.00 percent completed (processed: %u clusters)\r", p->current);
 	fflush(stdout);
 }


### PR DESCRIPTION
The new progress bar feature in the latest release of fsck is a very nice addition.However, during our recent testing, we identified two issues related to bitmap calculation and the progress bar display:

**1. Sign extension in count_bitmap_set_bits():**

When calculating the populated bits in the trailing bytes loop `for (; i < bytes; i++)`, `exfat->disk_bitmap[i]` is treated
as a signed `char` on some architectures. If the byte value is `0xff`, it triggers a sign extension when passed to `__builtin_popcount()`. Consequently,  `__builtin_popcount(0xff)` evaluates to `__builtin_popcount(0xffffffff)`, **returning 32 instead of the expected 8**.  This radically inflates the initial used cluster count.

**2. Progress bar exceeding 100%:**

When the filesystem bitmap is corrupted, the actual number of traversed clusters in the FAT chain can exceed the expected total cluster count derived from the bitmap. This causes the progress bar to print values over 100% (e.g., "139 percent completed"), 