### PR TITLE
dosattr: utils for DOS attributes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,9 +2,10 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = lib mkfs fsck tune label dump exfat2img
+SUBDIRS = lib mkfs fsck tune label dump exfat2img dosattr
 
 # manpages
+dist_man1_MANS =
 dist_man8_MANS =		\
 	manpages/fsck.exfat.8	\
 	manpages/tune.exfat.8	\
@@ -26,3 +27,10 @@ EXTRA_DIST =			\
 	dump/Android.bp		\
 	exfat2img/Android.bp	\
 	README.md
+
+if ENABLE_DOSATTR
+dist_man1_MANS +=		\
+	manpages/lsdosattr.1	\
+	manpages/chdosattr.1
+
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,15 @@ AC_CONFIG_FILES([
 	label/Makefile
 	dump/Makefile
 	exfat2img/Makefile
+	dosattr/Makefile
 ])
+
+AC_CHECK_HEADERS([fts.h], [have_fts_h="yes"])
+AM_CONDITIONAL([ENABLE_DOSATTR], [test "x$have_fts_h" == "xyes"])
+AM_COND_IF(
+	[ENABLE_DOSATTR],
+	[AC_CHECK_LIB([fts], [fts_open])],
+	[echo "<fts.h> not found. Not building dosattr programs"]
+)
 
 AC_OUTPUT

--- a/dosattr/Makefile.am
+++ b/dosattr/Makefile.am
@@ -1,0 +1,10 @@
+if ENABLE_DOSATTR
+AM_CFLAGS = -Wall -Wextra -include $(top_builddir)/config.h -I$(top_srcdir)/include -fno-common
+lsdosattr_LDADD = $(top_builddir)/lib/libexfat.a
+chdosattr_LDADD = $(top_builddir)/lib/libexfat.a
+
+sbin_PROGRAMS = lsdosattr chdosattr
+
+lsdosattr_SOURCES = lsdosattr.c
+chdosattr_SOURCES = chdosattr.c
+endif

--- a/dosattr/chdosattr.c
+++ b/dosattr/chdosattr.c
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *   Copyright (C) 2026 David Timber <dxdt@dev.snart.me>
+ */
+
+#include <stdbool.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <locale.h>
+#include <getopt.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "dosattr.h"
+
+const char *program_name = "chdosattr";
+
+enum Operator {
+	CHDOSATTR_OP_NONE,
+	CHDOSATTR_OP_ADD, /* add */
+	CHDOSATTR_OP_SUB, /* subtract */
+	CHDOSATTR_OP_ASS, /* assign */
+	NB_CHDOSATTR, /* assign */
+};
+
+static struct {
+	struct {
+		enum Operator op;
+		uint32_t operand;
+	} attr;
+	struct {
+		bool recursive;
+		bool version_only;
+		bool dirs;
+		bool help;
+	} f;
+} ui;
+
+static const struct {
+	char c;
+	uint32_t attr;
+} attrm[] = {
+	{ 'a', ATTR_ARCHIVE  },
+	/* { 'd', ATTR_SUBDIR   }, */
+	{ 'h', ATTR_HIDDEN   },
+	{ 'r', ATTR_READONLY },
+	{ 's', ATTR_SYSTEM   },
+	/* { 'v', ATTR_VOLUME   }, */
+};
+
+static uint32_t get_attrbyc(const char c)
+{
+	for (size_t i = 0; i < sizeof(attrm) / sizeof(attrm[0]); i += 1) {
+		if (attrm[i].c == c)
+			return attrm[i].attr;
+	}
+	return 0;
+}
+
+static uint32_t get_attrfromstr(const char *s)
+{
+	uint32_t ret = 0, tmp;
+
+	for (size_t i = 0; s[i] != 0; i += 1) {
+		tmp = get_attrbyc(s[i]);
+		if (tmp == 0)
+			return 0;
+		ret |= tmp;
+	}
+
+	return ret;
+}
+
+static void usage(void)
+{
+	fprintf(stderr, "Usage: %s [OPTION] ATTR FILE...\n", program_name);
+	fprintf(stderr, "Change the DOS attributes of each FILE to ATTR\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "\t-R  change files and directories recursively\n");
+	fprintf(stderr, "\t-V  show version\n");
+	fprintf(stderr, "\t-H  show help\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "ATTR is in the form of '[+-=]([ahrs]+)?'\n");
+
+	exit(DOSATTR_EXIT_USAGE);
+}
+
+static char *do_extract_argv(int off, int *argc, char **argv)
+{
+	char *ret = argv[off];
+
+	memmove(argv + off, argv + off + 1, sizeof(char *) * (*argc - off - 1));
+	*argc -= 1;
+	argv[*argc] = NULL;
+
+	return ret;
+}
+
+/*
+ * Extract the attribute operation spec from the argv so that the rest of args
+ * can be processed with getopt().
+ */
+static char *extract_attr_arg(int *argc, char **argv)
+{
+	int i;
+	enum Operator op;
+	uint32_t attrs;
+
+	for (i = 1; i < *argc; i += 1) {
+		if (argv[i] == NULL)
+			return NULL;
+
+		switch (argv[i][0]) {
+		case '+':
+			op = CHDOSATTR_OP_ADD;
+			break;
+		case '-':
+			op = CHDOSATTR_OP_SUB;
+			break;
+		case '=':
+			op = CHDOSATTR_OP_ASS;
+			break;
+		default:
+			continue;
+		}
+
+		switch (argv[i][0]) {
+		case '-':
+			/*
+			 * Does this option string contain chars other than dos
+			 * attr chars?
+			 */
+			attrs = get_attrfromstr(argv[i] + 1);
+			if (attrs == 0)
+				continue;
+
+			goto found;
+		/* args starting with '+' or '=' are definitely attr spec */
+		case '+':
+		case '=':
+			attrs = get_attrfromstr(argv[i] + 1);
+			/* '=' operator can used with no operand. i.e. clear everything */
+			if (attrs == 0 && op != CHDOSATTR_OP_ASS) {
+				fprintf(stderr,
+					"%s: %s: invalid attribute spec\n",
+					program_name, argv[i] + 1);
+				usage();
+			}
+
+			goto found;
+		}
+	}
+
+	return NULL;
+found:
+	ui.attr.op = op;
+	ui.attr.operand = attrs;
+	return do_extract_argv(i, argc, argv);
+}
+
+static bool do_set_attrs(const int fd, const char *path)
+{
+	uint32_t attrs;
+
+	assert(ui.attr.op > CHDOSATTR_OP_NONE && ui.attr.op < NB_CHDOSATTR);
+
+	switch (ui.attr.op) {
+	case CHDOSATTR_OP_ADD:
+	case CHDOSATTR_OP_SUB:
+		attrs = 0;
+		if (ioctl(fd, FAT_IOCTL_GET_ATTRIBUTES, &attrs) != 0) {
+			exfat_err("%s: getattr %s: %s\n",
+				program_name, path, strerror(errno));
+			return false;
+		}
+		break;
+	case CHDOSATTR_OP_ASS:
+		attrs = ui.attr.operand;
+		break;
+	default:
+		break;
+	}
+
+	switch (ui.attr.op) {
+	case CHDOSATTR_OP_ADD:
+		attrs |= ui.attr.operand;
+		break;
+	case CHDOSATTR_OP_SUB:
+		attrs &= ~ui.attr.operand;
+		break;
+	default:
+		break;
+	}
+
+	if (ioctl(fd, FAT_IOCTL_SET_ATTRIBUTES, &attrs) != 0) {
+		exfat_err("%s: setattr %s: %s\n",
+			program_name, path, strerror(errno));
+		return false;
+	}
+
+	return true;
+}
+
+static int do_chdosattr(FTSENT *ent, bool *skip)
+{
+	int fd;
+	bool ret;
+
+	if (!ui.f.recursive && S_ISDIR(ent->fts_statp->st_mode))
+		/* Don't visit the children */
+		*skip = true;
+
+	/*
+	 * FIXME: should check if fstatfs() fstype is exFAT or vfat before doing
+	 * ioctl()?
+	 */
+
+	fd = open(ent->fts_accpath, O_RDONLY);
+	if (fd < 0) {
+		exfat_err("%s: open %s: %s\n",
+			program_name, ent->fts_path, strerror(errno));
+		return 1;
+	}
+
+	ret = do_set_attrs(fd, ent->fts_path);
+
+	close(fd);
+
+	return ret ? 0 : -1;
+}
+
+int main(int argc, char *argv[])
+{
+	static int c;
+	static int retval;
+
+	setlocale(LC_MESSAGES, "");
+	setlocale(LC_CTYPE, "");
+
+	if (argc <= 1)
+		usage();
+
+	extract_attr_arg(&argc, argv);
+
+	while ((c = getopt(argc, argv, "RVH")) != -1) {
+		switch (c) {
+		case 'R':
+			ui.f.recursive = true;
+			break;
+		case 'V':
+			ui.f.version_only = true;
+			break;
+		case 'H':
+			ui.f.help = true;
+			break;
+		default:
+			usage();
+		}
+	}
+
+	if (ui.f.version_only)
+		show_version();
+	if (ui.f.help)
+		usage();
+	if (ui.f.help || ui.f.version_only)
+		exit(DOSATTR_EXIT_USAGE);
+
+	if (ui.attr.op == CHDOSATTR_OP_NONE) {
+		fprintf(stderr, "%s: no operation specified. Use -H option for help\n",
+			program_name);
+		exit(DOSATTR_EXIT_USAGE);
+	}
+
+	if (optind > argc - 1) {
+		fprintf(stderr, "%s: no file specified. Use -H option for help\n",
+			program_name);
+		exit(DOSATTR_EXIT_USAGE);
+	} else
+		retval = dosattr_fts((char * const *)(argv + optind),
+				do_chdosattr, FTS_PHYSICAL);
+
+	return retval;
+}

--- a/dosattr/dosattr.h
+++ b/dosattr/dosattr.h
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ *   Copyright (C) 2026 David Timber <dxdt@dev.snart.me>
+ */
+#ifndef _DOSATTR_H_
+#define _DOSATTR_H_
+
+/*
+ * Unfortunately, Linux doesn't provide a scalable and viable fs walk API and
+ * we're stuck with the interface with 16-bit signed integers. The state of FTS
+ * and ntfw() in Linux is such a mess at the moment, but FTS is still the best
+ * option that doesn't involve detrimental recursion.
+ */
+#include <fts.h>
+
+#include <linux/msdos_fs.h>
+#undef ATTR_HIDDEN
+#undef ATTR_VOLUME
+
+#include "exfat_ondisk.h"
+#include "libexfat.h"
+#include "version.h"
+
+#define DOSATTR_EXIT_USAGE	(2)
+#define DOSATTR_EXIT_PARTIAL	(3)
+
+typedef int (*fts_cb_f)(FTSENT *ent, bool *skip);
+
+extern const char *program_name;
+
+static int dosattr_fts_walk(FTS *fts, FTSENT *ent, fts_cb_f callback)
+{
+	int ret;
+	bool skip = false;
+
+	switch (ent->fts_info) {
+	case FTS_ERR:
+	case FTS_DNR:
+	case FTS_NS:
+		exfat_err("%s: %s: %s\n", program_name, ent->fts_path,
+			strerror(ent->fts_errno));
+		return 0;
+	case FTS_D:
+	case FTS_DOT:
+	case FTS_F:
+		break;
+	/* case FTS_DP: */
+	default:
+		return 0;
+	}
+
+	/* Reached if the entry being visited is a node */
+	assert(ent->fts_statp != NULL);
+
+	ret = callback(ent, &skip);
+	if (skip)
+		fts_set(fts, ent, FTS_SKIP);
+
+	return ret;
+}
+
+static int dosattr_fts(char *const *argv, fts_cb_f callback, const int options)
+{
+	FTSENT *ent;
+	FTS *fts;
+	int err = EXIT_SUCCESS, saved_errno;
+
+	fts = fts_open(argv, options, NULL);
+	if (fts == NULL)
+		return 1;
+
+	while ((ent = fts_read(fts)) != NULL) {
+		if (dosattr_fts_walk(fts, ent, callback) != 0) {
+			if (err == EXIT_SUCCESS)
+				err = EXIT_FAILURE;
+		} else if (err == EXIT_FAILURE)
+			err = DOSATTR_EXIT_PARTIAL;
+	}
+	saved_errno = errno;
+	fts_close(fts);
+	if (saved_errno != 0)
+		return EXIT_FAILURE;
+
+	return err;
+}
+
+#endif

--- a/dosattr/lsdosattr.c
+++ b/dosattr/lsdosattr.c
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *   Copyright (C) 2026 David Timber <dxdt@dev.snart.me>
+ */
+
+#include <stdbool.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <locale.h>
+#include <getopt.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "dosattr.h"
+
+const char *program_name = "lsdosattr";
+
+struct attrm {
+	const char *ro; /* ATTR_READONLY */
+	const char *hi; /* ATTR_HIDDEN   */
+	const char *sy; /* ATTR_SYSTEM   */
+	const char *vo; /* ATTR_VOLUME   */
+	const char *su; /* ATTR_SUBDIR   */
+	const char *ar; /* ATTR_ARCHIVE  */
+};
+
+static struct {
+	bool recursive;
+	bool version_only;
+	bool all;
+	bool dirs;
+	bool long_attrs;
+	bool verbose;
+	bool help;
+} ui;
+
+static const struct attrm attrm_short = {
+	.ro = "r",
+	.hi = "h",
+	.sy = "s",
+	.vo = "v",
+	.su = "d",
+	.ar = "a",
+};
+static const struct attrm attrm_long = {
+	.ro = "READONLY ",
+	.hi = "HIDDEN ",
+	.sy = "SYSTEM ",
+	.vo = "VOLUME ",
+	.su = "DIRECTORY ",
+	.ar = "ARCHIVED ",
+};
+static const struct attrm *attrm;
+
+static void usage(void)
+{
+	fprintf(stderr, "Usage: %s [OPTION] FILE...\n", program_name);
+	fprintf(stderr, "List the DOS attributes of each FILE\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "\t-R  list subdirectories recursively\n");
+	fprintf(stderr, "\t-a  do not ignore entries starting with a dot(.)\n");
+	fprintf(stderr, "\t-d  list directories themselves, not their contents\n");
+	fprintf(stderr,
+		"\t-l  use long attribute names instead of single character abbreviations\n");
+	fprintf(stderr, "\t-V  show version\n");
+	fprintf(stderr, "\t-h  show help\n");
+
+	exit(DOSATTR_EXIT_USAGE);
+}
+
+static void push_attrs(char *out, size_t *p, const char *a)
+{
+	const size_t al = strlen(a);
+
+	memcpy(out + *p, a, al);
+	*p += al;
+}
+
+static int list_attributes(FTSENT *ent, bool *skip)
+{
+	char attrs[sizeof("read-only hidden system volume directory archived ")];
+	char vdls[21];
+	size_t ap = 0;
+	uint32_t dosattrs = UINT32_MAX;
+	int fd;
+	int err = 0;
+#define PUSH_ATTRS(x) push_attrs(attrs, &ap, x)
+
+	if (!ui.recursive) {
+		if (ui.dirs || (S_ISDIR(ent->fts_statp->st_mode) && ent->fts_level > 0)) {
+			/* Don't visit the children, but the arg itself shouldn't be skipped */
+			*skip = true;
+		}
+	}
+	if (!ui.all && ent->fts_level > 0 && ent->fts_name[0] == '.') {
+		/* Skip the "hidden" node */
+		if (strcmp(ent->fts_name, ".") != 0 && strcmp(ent->fts_name, "..") != 0)
+			/* Don't touch SEEDOTS, though */
+			*skip = true;
+		return 0;
+	}
+
+	/*
+	 * FIXME: should do fstatfs() to get fstype before doing ioctl()? Should
+	 * I also work on NTFS in the future?
+	 */
+
+	fd = open(ent->fts_accpath, O_RDONLY);
+	if (fd < 0) {
+		exfat_err("%s: %s: %s\n", program_name, ent->fts_path, strerror(errno));
+		return 1;
+	}
+
+	if (ui.long_attrs)
+		attrs[0] = 0;
+	else
+		strncpy(attrs, "******", sizeof(attrs));
+
+	if (ioctl(fd, FAT_IOCTL_GET_ATTRIBUTES, &dosattrs) == 0) {
+		if (dosattrs & ATTR_READONLY)
+			PUSH_ATTRS(attrm->ro);
+		else if (!ui.long_attrs)
+			PUSH_ATTRS("-");
+
+		if (dosattrs & ATTR_HIDDEN)
+			PUSH_ATTRS(attrm->hi);
+		else if (!ui.long_attrs)
+			PUSH_ATTRS("-");
+
+		if (dosattrs & ATTR_SYSTEM)
+			PUSH_ATTRS(attrm->sy);
+		else if (!ui.long_attrs)
+			PUSH_ATTRS("-");
+
+		if (dosattrs & ATTR_VOLUME)
+			PUSH_ATTRS(attrm->vo);
+		else if (!ui.long_attrs)
+			PUSH_ATTRS("-");
+
+		if (dosattrs & ATTR_SUBDIR)
+			PUSH_ATTRS(attrm->su);
+		else if (!ui.long_attrs)
+			PUSH_ATTRS("-");
+
+		if (dosattrs & ATTR_ARCHIVE)
+			PUSH_ATTRS(attrm->ar);
+		else if (!ui.long_attrs)
+			PUSH_ATTRS("-");
+
+		attrs[ap] = 0;
+	} else if (errno != ENOTTY) {
+		err = 2;
+		exfat_err("%s: FAT_IOCTL_GET_ATTRIBUTES, %s: %s\n",
+			program_name, ent->fts_path, strerror(errno));
+	}
+
+	snprintf(vdls, sizeof(vdls), "%c", '*');
+	/*
+	 * The Linux community has decided that instead of introducing a new
+	 * IOCTL, the kernel should provide the VDL(valid data length)
+	 * information via SEEK_DATA/SEEK_HOLE interface. If the in-kernel exFAT
+	 * lseek() interface is "VDL-aware"(upcoming iomap patches), when the
+	 * VDL falls short of st->st_size, the VDL can be inferred from the fact
+	 * that SEEK_HOLE offset is less than EOF.
+	 *
+	 * Link: https://lore.kernel.org/linux-fsdevel/20260311222613.2010177-1-dxdt@dev.snart.me/
+	 *
+	 * Note that the VDL is in bytes but the kernel could round it up to
+	 * prevent inadvertent misaligned I/O.
+	 */
+	if (S_ISREG(ent->fts_statp->st_mode)) {
+		off_t vdl = lseek(fd, 0, SEEK_HOLE);
+
+		if (vdl < 0 && errno == ENXIO)
+			vdl = 0;
+
+		if (vdl >= 0) {
+			if (!ui.verbose && vdl == ent->fts_statp->st_size)
+				snprintf(vdls, sizeof(vdls), "%c", '=');
+			else
+				snprintf(vdls, sizeof(vdls), "%"PRIu64, (uint64_t)vdl);
+		} else if (errno != ENXIO) {
+			err = 2;
+			exfat_err("%s: lseek(), %s: %s\n", program_name,
+				  ent->fts_path, strerror(errno));
+		}
+	}
+
+	if (ui.long_attrs)
+		printf("%-28s %12"PRIu64" %12s %s\n",
+			ent->fts_path, ent->fts_statp->st_size, vdls, attrs);
+	else
+		printf("%s %12"PRIu64" %12s %s\n",
+			attrs, ent->fts_statp->st_size, vdls, ent->fts_path);
+
+	close(fd);
+	return err;
+#undef PUSH_ATTR
+}
+
+int main(int argc, char *argv[])
+{
+#define MY_FTSOPTS (FTS_PHYSICAL | FTS_SEEDOT)
+	static int c, retval;
+
+	setlocale(LC_MESSAGES, "");
+	setlocale(LC_CTYPE, "");
+
+	if (!(argc && *argv))
+		usage();
+
+	while ((c = getopt(argc, argv, "RVvadlh")) != EOF) {
+		switch (c) {
+		case 'R':
+			ui.recursive = true;
+			break;
+		case 'V':
+			ui.version_only = true;
+			break;
+		case 'v':
+			ui.verbose = true;
+			break;
+		case 'a':
+			ui.all = true;
+			break;
+		case 'd':
+			ui.dirs = true;
+			break;
+		case 'l':
+			ui.long_attrs = true;
+			break;
+		case 'h':
+			ui.help = true;
+			break;
+		default:
+			usage();
+		}
+	}
+
+	if (ui.version_only)
+		show_version();
+	if (ui.help)
+		usage();
+	if (ui.help || ui.version_only)
+		exit(DOSATTR_EXIT_USAGE);
+
+	if (ui.long_attrs)
+		attrm = &attrm_long;
+	else
+		attrm = &attrm_short;
+
+	if (optind > argc - 1) {
+		static const char *const DEFAULT_ARGV[] = { ".", NULL };
+
+		retval = dosattr_fts((char * const *)DEFAULT_ARGV,
+				list_attributes, MY_FTSOPTS);
+	} else
+		retval = dosattr_fts((char * const *)(argv + optind),
+				list_attributes, MY_FTSOPTS);
+
+	return retval;
+}

--- a/manpages/chdosattr.1
+++ b/manpages/chdosattr.1
@@ -1,0 +1,79 @@
+.TH chdosattr 1
+.SH NAME
+chdosattr \- change DOS file attributes
+.SH SYNOPSIS
+.B chdosattr
+[
+.B \-RVH
+]
+.I ATTR
+.I FILES...
+
+.SH DESCRIPTION
+.P
+.B chdosattr
+changes the following DOS attributes of files:
+.IP
+\fBr\fP (READONLY)
+.IP
+\fBh\fP (HIDDEN)
+.IP
+\fBs\fP (SYSTEM)
+.IP
+\fBa\fP (ARCHIVED)
+.P
+The format of \fIATTR\fP is in two parts, in the format of
+[\fB\+\-\=\fP][\fBahrs\fP], where the first part is the operator spec the second
+part the DOS attributes. The operator \fB\+\fP causes the specified DOS
+attributes to be added the existing DOS attribute set; \fB\-\fP causes them to
+be removed; and \fB\=\fP causes them to be added and causes unmentioned DOS
+attributes to be removed. If the operator part is omitted, \fB\=\fP is assumed.
+
+.SH OPTIONS
+.TP
+.B \-R
+Change files and directories recursively
+.TP
+.B \-V
+Show version
+.TP
+.B \-H
+Show help
+
+.SH EXIT STATUS
+.TP
+.B 0
+on success
+.TP
+.B 1
+when no file could modified
+.TP
+.B 2
+on usage error
+.TP
+.B 3
+when an error occurred but at least one file has been successfully modified
+
+.SH BUGS AND LIMITATIONS
+.P
+The modification of the DOS attribute \fBs\fP(SYSTEM) requires
+\fBCAP_LINUX_IMMUTABLE\fP(see capabilities(7)).
+
+.P
+For obvious reasons, the DOS attributes \fBs\fP(DIRECTORY) and \fBv\fP(VOLUME)
+cannot be altered.
+
+.SH NOTE
+.P
+In vFAT, exFAT and NTFS, only the READONLY attribute is controlled through owner
+write permission bit. Linux kernel always sets ARCHIVE on files it creates and
+modifies. HIDDEN and SYSTEM can only be controlled through \fB ioctl_fat\fP(2).
+\fBlsdosattr\fP(1) and \fBchdosattr\fP(1) are the wrappers for the ioctl.
+
+.SH SEE ALSO
+.BR chmod (1),
+.BR chattr (1),
+.BR ioctl_fat (2)
+and the documentation on
+.B ATTRIB
+command in Microsoft Windows and various DOS.

--- a/manpages/lsdosattr.1
+++ b/manpages/lsdosattr.1
@@ -1,0 +1,87 @@
+.TH lsdosattr 1
+.SH NAME
+lsdosattr \- list DOS file attributes
+.SH SYNOPSIS
+.B lsdosattr
+[
+.B \-RadlVh
+]
+[
+.I FILES...
+]
+.SH DESCRIPTION
+.P
+.B lsdosattr
+lists the DOS attributes, size and VDL(valid data length) of files. The DOS
+attributes are
+.IP
+\fBr\fP (READONLY)
+.IP
+\fBh\fP (HIDDEN)
+.IP
+\fBs\fP (SYSTEM)
+.IP
+\fBv\fP (VOLUME)
+.IP
+\fBs\fP (DIRECTORY)
+.IP
+\fBa\fP (ARCHIVED)
+.P
+Each file is shown in 4 columns that represent the attributes, size, VDL of the
+file. When the option \fB\-l\fP is used, the columns are shown in the order of file
+name, size, VDL and long attributes.
+
+.SH OPTIONS
+.TP
+.B \-R
+List subdirectories recursively
+.TP
+.B \-a
+Do not ignore entries starting with a dot('.')
+.TP
+.B \-d
+List directories themselves, not their contents
+.TP
+.B \-l
+Use long attribute names instead of single character abbreviations
+.TP
+.B \-V
+Show version
+.TP
+.B \-h
+Show help
+
+.SH EXIT STATUS
+.TP
+.B 0
+on success
+.TP
+.B 1
+when no file could be listed
+.TP
+.B 2
+on usage error
+.TP
+.B 3
+when an error occurred but at least one file was successfully listed
+
+.SH NOTE
+.P
+Linux kernel does not provide a special interface for reading the VDL(valid data
+length). If the in-kernel exFAT implementation is "VDL-aware", the VDL offset is
+treated as the start of the "hole"(\fBSEEK_HOLE\fP) that ranges to EOF.
+Therefore, the approximate VDL can be inferred from \fBlseek\fP(2) and this is
+why \fBlsdosattr\fP merely prints the first hole it encounters as the VDL.
+
+.P
+In vFAT, exFAT and NTFS, only the READONLY attribute is controlled through owner
+write permission bit. Linux kernel always sets ARCHIVE on files it creates and
+modifies. HIDDEN and SYSTEM can only be controlled through \fB ioctl_fat\fP(2).
+\fBlsdosattr\fP(1) and \fBchdosattr\fP(1) are the wrappers for the ioctl.
+
+.SH SEE ALSO
+.BR lsattr (1),
+.BR ioctl_fat (2)
+and the documentation on
+.B ATTRIB
+command in Microsoft Windows and various DOS.


### PR DESCRIPTION
Add util programs, lsdosattr and chdosattr, the (ex)FAT and NTFS equivalent of lsattr and chattr fom e2fsprogs or the Linux interpretation of the historic DOS and Windows command ATTRIB.

chdosattr introduces abilities to change ATTR_HIDDEN and ATTR_ARCHIVE to userland. Prior to this, only the modification of ATTR_READONLY was possible through the modification of owner write permissions.

lsdosattr also treats the offsets to the first SEEK_HOLE as the VDL. This feature will be added to the upcoming version of in-kernel exFAT.

Link: https://lore.kernel.org/linux-fsdevel/20260311222613.2010177-1-dxdt@dev.snart.me/