### PR TITLE
Fix minor bugs, refactor I/O, add user warning on sector size mismatch, memory optimisation for huge bitmap

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -180,7 +180,7 @@ jobs:
           done
         done
 
-        tar -S -cf "images-${{ matrix.name }}.tar" "images-${{ matrix.name }}"
+        tar -cf "images-${{ matrix.name }}.tar" "images-${{ matrix.name }}"
         TAR_FILE="$(realpath "images-${{ matrix.name }}.tar")"
         popd
 
@@ -208,7 +208,7 @@ jobs:
       run: |
         set -e
 
-        tar -S -C /c -xf images-${{ matrix.name }}.tar
+        tar -C /c -xf images-${{ matrix.name }}.tar
 
         for bs in $TEST_BLOCKSIZES
         do

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -54,13 +54,22 @@ jobs:
         sudo apt-get install -y linux-modules-extra-$(uname -r)
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
         export PATH=/usr/local/lib:$PATH
-    - name: build test & install exfatprogs
+    - name: Bootstrap build system
+      run: ./autogen.sh
+    - name: Test building exfatprogs on arbitrary directory
+      shell: bash
       run: |
-        ./autogen.sh
-        ./configure
+        set -e
+        CONFIG_SCRIPT="$(realpath ./configure)"
+
+        pushd "$(mktemp -d)"
+        "${CONFIG_SCRIPT}"
         make -j$((`nproc`+1))
         sudo make install
         make distclean
+        popd
+    - name: Build exfatprogs for test target
+      run: |
         ./configure --host=${{ matrix.host }} CFLAGS=--static
         make -j$((`nproc`+1))
     - name: run fsck repair testcases
@@ -175,7 +184,7 @@ jobs:
         TAR_FILE="$(realpath "images-${{ matrix.name }}.tar")"
         popd
 
-        mv "$TAR_FILE" .
+        mv -f "$TAR_FILE" .
     - name: Stage image bundle as artifact
       uses: actions/upload-artifact@v7
       with:

--- a/defrag/defrag.c
+++ b/defrag/defrag.c
@@ -49,24 +49,24 @@ static void sigint_handler(int sig)
 static int exfat_rw_FAT(struct exfat *exfat, uint32_t *list, uint32_t list_len, bool read)
 {
 	off_t offset;
-	size_t len_1, len_2;
+	bool ret;
+	const size_t len = (size_t)(list_len * sizeof(uint32_t));
 	uint32_t i;
 
 	offset = (off_t)le32_to_cpu(exfat->bs->bsx.fat_offset) << exfat->bs->bsx.sect_size_bits;
-	len_1 = (size_t)(list_len * sizeof(uint32_t));
 
 	/* Read or write with endianness conversion */
 	if (read) {
-		len_2 = exfat_read(exfat->blk_dev->dev_fd, list, len_1, offset);
-		if (len_2 != len_1)
+		ret = exfat_read_full(exfat->blk_dev->dev_fd, list, len, offset);
+		if (!ret)
 			return -EIO;
 		for (i = 0; i < list_len; i++)
 			list[i] = le32_to_cpu(list[i]);
 	} else {
 		for (i = 0; i < list_len; i++)
 			list[i] = cpu_to_le32(list[i]);
-		len_2 = exfat_write(exfat->blk_dev->dev_fd, list, len_1, offset);
-		if (len_2 != len_1)
+		ret = exfat_write_full(exfat->blk_dev->dev_fd, list, len, offset);
+		if (!ret)
 			return -EIO;
 	}
 
@@ -79,7 +79,7 @@ static int exfat_rw_FAT(struct exfat *exfat, uint32_t *list, uint32_t list_len, 
  */
 static int exfat_rw_bitmap(struct exfat *exfat, bool read)
 {
-	ssize_t rw_len = 0;
+	bool rw;
 
 	struct exfat_dentry *dentry;
 	struct exfat_lookup_filter filter = {
@@ -116,16 +116,16 @@ static int exfat_rw_bitmap(struct exfat *exfat, bool read)
 
 	/* Perform read or write operation */
 	if (read) {
-		rw_len = exfat_read(exfat->blk_dev->dev_fd, exfat->alloc_bitmap,
+		rw = exfat_read_full(exfat->blk_dev->dev_fd, exfat->alloc_bitmap,
 					exfat->disk_bitmap_size,
 					exfat_c2o(exfat, exfat->disk_bitmap_clus));
-		if (rw_len != exfat->disk_bitmap_size)
+		if (!rw)
 			return -EIO;
 	} else {
-		rw_len = exfat_write(exfat->blk_dev->dev_fd, exfat->alloc_bitmap,
+		rw = exfat_write_full(exfat->blk_dev->dev_fd, exfat->alloc_bitmap,
 					exfat->disk_bitmap_size,
 					exfat_c2o(exfat, exfat->disk_bitmap_clus));
-		if (rw_len != exfat->disk_bitmap_size)
+		if (!rw)
 			return -EIO;
 	}
 
@@ -689,16 +689,16 @@ err:
 static int exfat_rw_clu(struct exfat *exfat, void *tmp, uint32_t cluster, bool read)
 {
 	off_t offset;
-	size_t rw_len;
+	bool ret;
 
 	offset = (off_t)exfat_c2o(exfat, cluster);
 
 	if (read)
-		rw_len = exfat_read(exfat->blk_dev->dev_fd, tmp, (size_t)exfat->clus_size, offset);
+		ret = exfat_read_full(exfat->blk_dev->dev_fd, tmp, exfat->clus_size, offset);
 	else
-		rw_len = exfat_write(exfat->blk_dev->dev_fd, tmp, (size_t)exfat->clus_size, offset);
+		ret = exfat_write_full(exfat->blk_dev->dev_fd, tmp, exfat->clus_size, offset);
 
-	if (rw_len != (size_t)exfat->clus_size)
+	if (!ret)
 		return -EIO;
 
 	return 0;

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -216,13 +216,12 @@ static int exfat_show_fs_info(struct exfat *exfat)
 		dump_field("Bitmap size", "%llu", bitmap_len);
 
 		if (bitmap_len > EXFAT_BITMAP_SIZE(exfat->clus_count)) {
-			exfat_err("Invalid bitmap size\n");
+			exfat_err("Invalid bitmap size: %llu\n", bitmap_len);
 			return -EINVAL;
 		}
 
-		ret = exfat_read(bd->dev_fd, exfat->disk_bitmap, bitmap_len,
-				exfat_c2o(exfat, bitmap_clu));
-		if (ret < 0) {
+		if (!exfat_read_full(bd->dev_fd, exfat->disk_bitmap, bitmap_len,
+				exfat_c2o(exfat, bitmap_clu))) {
 			exfat_err("bitmap read failed: %d\n", errno);
 			return -EIO;
 		}

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -919,7 +919,7 @@ int main(int argc, char *argv[])
 {
 	int c;
 	int ret = EXIT_FAILURE;
-	struct exfat_blk_dev bd;
+	struct exfat_blk_dev bd = { 0, };
 	struct exfat_user_input ui;
 	bool version_only = false;
 	struct exfat *exfat;

--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -153,7 +153,7 @@ static ssize_t dump_range(struct exfat2img *ei, off_t start, off_t end)
 {
 	struct exfat *exfat = ei->exfat;
 	size_t len, total_len = 0;
-	ssize_t ret;
+	bool ret;
 
 	if (ei->is_stdout) {
 		unsigned int sc, sc_offset;
@@ -169,19 +169,22 @@ static ssize_t dump_range(struct exfat2img *ei, off_t start, off_t end)
 	}
 
 	while (start < end) {
-		len = (size_t)MIN(end - start, exfat->clus_size);
+		off_t range_delta = end - start;
 
-		ret = exfat_read(exfat->blk_dev->dev_fd,
+		range_delta = MIN(range_delta, SSIZE_MAX);
+		len = MIN((size_t)range_delta, exfat->clus_size);
+
+		ret = exfat_read_full(exfat->blk_dev->dev_fd,
 				 ei->dump_cluster, len, start);
-		if (ret != (ssize_t)len) {
+		if (!ret) {
 			exfat_err("failed to read %llu bytes at %llu\n",
 				  (unsigned long long)len,
 				  (unsigned long long)start);
 			return -EIO;
 		}
 
-		ret = pwrite(ei->out_fd, ei->dump_cluster, len, start);
-		if (ret != (ssize_t)len) {
+		ret = exfat_write_full(ei->out_fd, ei->dump_cluster, len, start);
+		if (!ret) {
 			exfat_err("failed to write %llu bytes at %llu\n",
 				  (unsigned long long)len,
 				  (unsigned long long)start);
@@ -542,7 +545,7 @@ static int dump_bytes_to_stdout(struct exfat2img *ei,
 {
 	struct exfat *exfat = ei->exfat;
 	size_t len;
-	ssize_t ret;
+	bool ret;
 
 	if (start != ei->stdout_offset) {
 		exfat_err("try to skip for stdout at %llu, expected: %llu\n",
@@ -553,17 +556,17 @@ static int dump_bytes_to_stdout(struct exfat2img *ei,
 
 	while (start < end_excl) {
 		len = (size_t)MIN(end_excl - start, exfat->clus_size);
-		ret = exfat_read(exfat->blk_dev->dev_fd, ei->dump_cluster,
+		ret = exfat_read_full(exfat->blk_dev->dev_fd, ei->dump_cluster,
 				 len, start);
-		if (ret != (ssize_t)len) {
+		if (!ret) {
 			exfat_err("failed to read %llu bytes at %llu\n",
 				  (unsigned long long)len,
 				  (unsigned long long)start);
 			return -EIO;
 		}
 
-		ret = write(ei->out_fd, ei->dump_cluster, len);
-		if (ret != (ssize_t)len) {
+		ret = exfat_write_full(ei->out_fd, ei->dump_cluster, len, -1);
+		if (!ret) {
 			exfat_err("failed to write %llu bytes at %llu\n",
 				  (unsigned long long)len,
 				  (unsigned long long)start);
@@ -608,7 +611,7 @@ static int dump_clusters_to_stdout(struct exfat2img *ei,
 			buf[0] = cc;
 			*((__le32 *)&buf[1]) =
 				cpu_to_le32(cc_clu_count);
-			if (write(ei->out_fd, buf, cc_len) != (ssize_t)cc_len) {
+			if (!exfat_write_full(ei->out_fd, buf, cc_len, -1)) {
 				exfat_err("failed to write cc %d : %u\n for %u ~ %u clusters\n",
 					  cc, cc_clu_count,
 					  start_clu, start_clu + cc_clu_count - 1);
@@ -707,7 +710,7 @@ static int dump_header(struct exfat2img *ei)
 	ei_hdr.cluster_size = cpu_to_le32(exfat->clus_size);
 	ei_hdr.cluster_count = cpu_to_le32(exfat->clus_count);
 
-	if (write(ei->out_fd, &ei_hdr, sizeof(ei_hdr)) != (ssize_t)sizeof(ei_hdr)) {
+	if (!exfat_write_full(ei->out_fd, &ei_hdr, sizeof(ei_hdr), -1)) {
 		exfat_err("failed to write exfat2img header\n");
 		return -EIO;
 	}
@@ -720,7 +723,7 @@ static ssize_t read_stream(int fd, void *buf, size_t len)
 	ssize_t ret;
 
 	while (read_len < len) {
-		ret = read(fd, buf, len - read_len);
+		ret = exfat_read(fd, buf, len - read_len, -1);
 		if (ret < 0) {
 			if (errno != -EAGAIN && errno != -EINTR)
 				return -1;
@@ -784,8 +787,7 @@ static int restore_from_stdin(struct exfat2img *ei)
 			goto out;
 		}
 
-		if (pwrite(ei->out_fd, ei->dump_cluster, len, out_start_off)
-		    != (ssize_t)len) {
+		if (!exfat_write_full(ei->out_fd, ei->dump_cluster, len, out_start_off)) {
 			exfat_err("failed to write first meta region. %llu ~ %llu\n",
 				  (unsigned long long)out_start_off,
 				  (unsigned long long)out_start_off + len);
@@ -838,8 +840,8 @@ static int restore_from_stdin(struct exfat2img *ei)
 					ret = -EIO;
 					goto out;
 				}
-				if (pwrite(ei->out_fd, ei->dump_cluster,
-					   clus_size, out_start_off) != (ssize_t)clus_size) {
+				if (!exfat_write_full(ei->out_fd, ei->dump_cluster,
+						      clus_size, out_start_off)) {
 					exfat_err("failed to write range %llu ~ %llu\n",
 						  (unsigned long long)out_start_off,
 						  (unsigned long long)out_start_off + clus_size);

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -311,9 +311,8 @@ static int boot_region_checksum(int dev_fd,
 
 	checksum = 0;
 	for (i = 0; i < 11; i++) {
-		if (exfat_read(dev_fd, sect, sect_size,
-				bs_offset * sect_size + i * sect_size) !=
-				(ssize_t)sect_size) {
+		if (!exfat_read_full(dev_fd, sect, sect_size,
+				bs_offset * sect_size + i * sect_size)) {
 			exfat_err("failed to read boot region\n");
 			ret = -EIO;
 			goto out;
@@ -321,9 +320,8 @@ static int boot_region_checksum(int dev_fd,
 		boot_calc_checksum(sect, sect_size, i == 0, &checksum);
 	}
 
-	if (exfat_read(dev_fd, sect, sect_size,
-			bs_offset * sect_size + 11 * sect_size) !=
-			(ssize_t)sect_size) {
+	if (!exfat_read_full(dev_fd, sect, sect_size,
+			bs_offset * sect_size + 11 * sect_size)) {
 		exfat_err("failed to read a boot checksum sector\n");
 		ret = -EIO;
 		goto out;
@@ -353,8 +351,7 @@ static int exfat_mark_volume_dirty(struct exfat *exfat, bool dirty)
 		flags &= ~0x02;
 
 	exfat->bs->bsx.vol_flags = cpu_to_le16(flags);
-	if (exfat_write(exfat->blk_dev->dev_fd, exfat->bs,
-			sizeof(struct pbr), 0) != (ssize_t)sizeof(struct pbr)) {
+	if (!exfat_write_full(exfat->blk_dev->dev_fd, exfat->bs, sizeof(struct pbr), 0)) {
 		exfat_err("failed to set VolumeDirty\n");
 		return -EIO;
 	}
@@ -381,8 +378,7 @@ static int read_boot_region(struct exfat_blk_dev *bd, struct pbr **pbr,
 		return -ENOMEM;
 	}
 
-	if (exfat_read(bd->dev_fd, bs, sizeof(*bs),
-			bs_offset * sect_size) != (ssize_t)sizeof(*bs)) {
+	if (!exfat_read_full(bd->dev_fd, bs, sizeof(*bs), bs_offset * sect_size)) {
 		exfat_err("failed to read a boot sector\n");
 		ret = -EIO;
 		goto err;
@@ -464,20 +460,16 @@ static int restore_boot_region(struct exfat_blk_dev *bd, unsigned int sect_size)
 		return -ENOMEM;
 
 	for (i = 0; i < 12; i++) {
-		if (exfat_read(bd->dev_fd, sector, sect_size,
-				BACKUP_BOOT_SEC_IDX * sect_size +
-				i * sect_size) !=
-				(ssize_t)sect_size) {
+		if (!exfat_read_full(bd->dev_fd, sector, sect_size,
+				     BACKUP_BOOT_SEC_IDX * sect_size + i * sect_size)) {
 			ret = -EIO;
 			goto free_sector;
 		}
 		if (i == 0)
 			((struct pbr *)sector)->bsx.perc_in_use = 0xff;
 
-		if (exfat_write(bd->dev_fd, sector, sect_size,
-				BOOT_SEC_IDX * sect_size +
-				i * sect_size) !=
-				(ssize_t)sect_size) {
+		if (!exfat_write_full(bd->dev_fd, sector, sect_size,
+				      BOOT_SEC_IDX * sect_size + i * sect_size)) {
 			ret = -EIO;
 			goto free_sector;
 		}
@@ -507,8 +499,7 @@ static int exfat_boot_region_check(struct exfat_blk_dev *blkdev,
 	if (boot_sect == NULL)
 		return -ENOMEM;
 
-	if (exfat_read(blkdev->dev_fd, boot_sect,
-		       sizeof(*boot_sect), 0) != (ssize_t)sizeof(*boot_sect)) {
+	if (!exfat_read_full(blkdev->dev_fd, boot_sect, sizeof(*boot_sect), 0)) {
 		exfat_err("failed to read Main boot sector\n");
 		free(boot_sect);
 		return -EIO;
@@ -999,8 +990,8 @@ static int read_bitmap(struct exfat *exfat)
 		exfat_repair_ask(&exfat_fsck, ER_DE_BITMAP,
 				"ERROR: invalid bitmap size. %lld", map_size)) {
 		dentry->bitmap_size = cpu_to_le64(need_map_size);
-		if (pwrite(exfat->blk_dev->dev_fd, dentry, DENTRY_SIZE,
-				filter.out.dev_offset) != DENTRY_SIZE) {
+		if (!exfat_write_full(exfat->blk_dev->dev_fd, dentry, DENTRY_SIZE,
+				      filter.out.dev_offset)) {
 			exfat_err("failed to write bitmap dentry\n");
 			return -EIO;
 		}
@@ -1027,10 +1018,9 @@ static int read_bitmap(struct exfat *exfat)
 			       le32_to_cpu(dentry->bitmap_start_clu),
 			       DIV_ROUND_UP(exfat->disk_bitmap_size,
 					    exfat->clus_size));
-	if (exfat_read(exfat->blk_dev->dev_fd, exfat->disk_bitmap,
+	if (!exfat_read_full(exfat->blk_dev->dev_fd, exfat->disk_bitmap,
 			exfat->disk_bitmap_size,
-			exfat_c2o(exfat, exfat->disk_bitmap_clus)) !=
-			(ssize_t)exfat->disk_bitmap_size)
+			exfat_c2o(exfat, exfat->disk_bitmap_clus)))
 		retval = -EIO;
 out:
 	free(filter.out.dentry_set);
@@ -1066,7 +1056,6 @@ static bool exfat_has_default_upcase_table(struct exfat *exfat, clus_t *clu)
 {
 	char *upcase;
 	bool ret = false;
-	int size;
 	clus_t def_clu = DIV_ROUND_UP(EXFAT_BITMAP_SIZE(exfat->clus_count),
 			exfat->clus_size) + EXFAT_FIRST_CLUSTER;
 
@@ -1078,11 +1067,9 @@ static bool exfat_has_default_upcase_table(struct exfat *exfat, clus_t *clu)
 		*clu = def_clu;
 
 again:
-	size = pread(exfat->blk_dev->dev_fd, upcase,
-			sizeof(default_upcase_table),
-			exfat_c2o(exfat, *clu));
-	if (size == sizeof(default_upcase_table)) {
-		if (!memcmp(upcase, default_upcase_table, size)) {
+	if (exfat_read_full(exfat->blk_dev->dev_fd, upcase, sizeof(default_upcase_table),
+			    exfat_c2o(exfat, *clu))) {
+		if (!memcmp(upcase, default_upcase_table, sizeof(default_upcase_table))) {
 			ret = true;
 			goto out;
 		}
@@ -1103,7 +1090,7 @@ static int exfat_repair_upcase_table(struct exfat *exfat,
 		struct exfat_dentry *dentry, off_t dentry_off)
 {
 	clus_t clu;
-	int ret;
+	bool ret;
 	off_t upcase_off;
 	size_t nbytes;
 	struct exfat_dentry ed;
@@ -1138,9 +1125,9 @@ static int exfat_repair_upcase_table(struct exfat *exfat,
 		}
 
 		upcase_off = exfat_c2o(exfat, clu);
-		ret = pwrite(fd, default_upcase_table,
-			     sizeof(default_upcase_table), upcase_off);
-		if (ret != sizeof(default_upcase_table)) {
+		ret = exfat_write_full(fd, default_upcase_table,
+					sizeof(default_upcase_table), upcase_off);
+		if (!ret) {
 			exfat_err("failed to write new upcase_table\n");
 			return -EIO;
 		}
@@ -1167,7 +1154,8 @@ static int exfat_repair_upcase_table(struct exfat *exfat,
 	dentry->upcase_size = cpu_to_le64(sizeof(default_upcase_table));
 
 	/* Write upcase table dentry */
-	if (pwrite(fd, dentry, DENTRY_SIZE, dentry_off) != DENTRY_SIZE) {
+	ret = exfat_write_full(fd, dentry, DENTRY_SIZE, dentry_off);
+	if (!ret) {
 		exfat_err("failed to write upcase_table dentry\n");
 		return -EIO;
 	}
@@ -1237,9 +1225,9 @@ static int read_upcase_table(struct exfat_fsck *fsck)
 		goto out;
 	}
 
-	if (exfat_read(exfat->blk_dev->dev_fd, upcase, size,
+	if (!exfat_read_full(exfat->blk_dev->dev_fd, upcase, size,
 			exfat_c2o(exfat,
-			le32_to_cpu(dentry->upcase_start_clu))) != size) {
+			le32_to_cpu(dentry->upcase_start_clu)))) {
 		exfat_err("failed to read upcase table\n");
 		retval = -EIO;
 		goto out;
@@ -1471,9 +1459,9 @@ static int write_bitmap(struct exfat_fsck *fsck)
 		byte_offset = ((i * sizeof(bitmap_t)) / 512) * 512;
 		write_bytes = MIN(512, bitmap_bytes - byte_offset);
 
-		if (exfat_write(exfat->blk_dev->dev_fd,
+		if (!exfat_write_full(exfat->blk_dev->dev_fd,
 				(char *)ohead_b + byte_offset, write_bytes,
-				dev_offset + byte_offset) != (ssize_t)write_bytes)
+				dev_offset + byte_offset))
 			return -EIO;
 
 		i = (byte_offset + write_bytes) / sizeof(bitmap_t);

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -174,8 +174,41 @@ void boot_calc_checksum(const unsigned char *sector, size_t size,
 void init_user_input(struct exfat_user_input *ui);
 int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 		struct exfat_blk_dev *bd);
+/*
+ * Load the requested size of data from the file onto buf
+ *
+ * The function ensures that all of the requested size has been read and memory
+ * at buf contains the data read from the file. If offset is a negative value,
+ * read() is used. Otherwise, pread() is used to do I/O.
+ *
+ * If all of the size cannot be read due to an error, -errno is returned.
+ * Otherwise, the number of bytes read is returned. Note that the number of
+ * bytes returned may be less than the size requested.
+ *
+ * Note that the function will read SSIZE_MAX bytes(~2GB on 32-bit arch) at most
+ * due to interface limitations. exfat_read2() has no such limitation.
+ */
 ssize_t exfat_read(int fd, void *buf, size_t size, off_t offset);
-ssize_t exfat_write(int fd, void *buf, size_t size, off_t offset);
+int exfat_read2(int fd, void *buf, off_t *size, off_t *offset);
+/*
+ * Write the requested buffer to the file
+ *
+ * The function ensures that all of the requested buffer has been written to the
+ * file. If offset is a negative value, write() is used. Otherwise, pwrite() is
+ * used to do I/O.
+ *
+ * If all of the buffer data cannot be written read due to an error, -errno.
+ * Otherwise, the number of bytes successfully written is returned.
+ *
+ * Note that the function will write SSIZE_MAX bytes(~2GB on 32-bit arch) at
+ * most due to interface limitations. exfat_write2() has no such limitation.
+ *
+ * In case of an error, the caller cannot determine how much data has been
+ * written to the file with the function. exfat_write2() may be used where such
+ * info is required.
+ */
+ssize_t exfat_write(int fd, const void *buf, size_t size, off_t offset);
+int exfat_write2(int fd, const void *buf, off_t *size, off_t *offset);
 int exfat_write_zero(int fd, off_t size, off_t offset);
 int exfat_write_zero2(int fd, off_t size, off_t offset, size_t bs);
 int exfat_discard_blocks(int fd, uint64_t start, uint64_t len);

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -283,9 +283,25 @@ void exfat_close_fd_devzero(void);
  *
  * Note that /dev/zero mapping do not count towards committed memory. See
  * vm.overcommit for detail.
+ *
+ * For rw version of this function, see exfat_map_blankmem().
  */
 const void *exfat_map_zeromem(const size_t len, bool *mapped);
-int exfat_unmap_zeromem(const void *m, const size_t len, const bool *mapped);
+/*
+ * Map read-writeable pages suitable for composing binary data containing mostly
+ * zeros(e.g. allocation bitmap).
+ *
+ * The function has the exact same semantics as exfat_map_zeromem(), except that
+ * it calls mmap() with PROT_READ|PROT_WRITE and MAP_PRIVATE.
+ */
+void *exfat_map_blankmem(const size_t len, bool *mapped);
+/*
+ * Unmap memory mapping mapped with exfat_map_zeromem() and exfat_map_blankmem().
+ *
+ * If mapped is set, call munmap(), clear mapped unset and return the value
+ * returned from munmap(). Otherwise, call free() and return 0.
+ */
+int exfat_unmap_mm(const void *m, const size_t len, bool *mapped);
 
 /*
  * Exfat Print

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -190,6 +190,7 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
  */
 ssize_t exfat_read(int fd, void *buf, size_t size, off_t offset);
 int exfat_read2(int fd, void *buf, off_t *size, off_t *offset);
+bool exfat_read_full(int fd, void *buf, size_t size, off_t offset);
 /*
  * Write the requested buffer to the file
  *
@@ -209,6 +210,7 @@ int exfat_read2(int fd, void *buf, off_t *size, off_t *offset);
  */
 ssize_t exfat_write(int fd, const void *buf, size_t size, off_t offset);
 int exfat_write2(int fd, const void *buf, off_t *size, off_t *offset);
+bool exfat_write_full(int fd, const void *buf, size_t size, off_t offset);
 int exfat_write_zero(int fd, off_t size, off_t offset);
 int exfat_write_zero2(int fd, off_t size, off_t offset, size_t bs);
 int exfat_discard_blocks(int fd, uint64_t start, uint64_t len);

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -79,6 +79,7 @@ struct exfat_blk_dev {
 	unsigned long long num_sectors;
 	unsigned int num_clusters;
 	unsigned int cluster_size;
+	unsigned int dev_sector_size;
 	bool isblk;
 };
 

--- a/label/label.c
+++ b/label/label.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[])
 {
 	int c;
 	int ret = EXIT_FAILURE;
-	struct exfat_blk_dev bd;
+	struct exfat_blk_dev bd = { 0, };
 	struct exfat_user_input ui;
 	bool version_only = false;
 	int serial_mode = 0;

--- a/lib/exfat_dir.c
+++ b/lib/exfat_dir.c
@@ -47,11 +47,10 @@ static ssize_t write_block(struct exfat_de_iter *iter, unsigned int block)
 		if (BITMAP_GET(desc->dirty, i)) {
 			device_offset = exfat_c2o(exfat, desc->p_clus) +
 				desc->offset;
-			if (exfat_write(exfat->blk_dev->dev_fd,
+			if (!exfat_write_full(exfat->blk_dev->dev_fd,
 					desc->buffer + i * iter->write_size,
 					iter->write_size,
-					device_offset + i * iter->write_size)
-					!= (ssize_t)iter->write_size)
+					device_offset + i * iter->write_size))
 				return -EIO;
 			BITMAP_CLEAR(desc->dirty, i);
 		}
@@ -384,8 +383,8 @@ int exfat_de_iter_revert(struct exfat_de_iter *iter, int num)
 	dest_bd->p_clus = clu;
 	dest_bd->offset = offset;
 
-	if (exfat_read(exfat->blk_dev->dev_fd, dest_bd->buffer, iter->read_size,
-			exfat_c2o(exfat, clu) + offset) != (ssize_t)iter->read_size)
+	if (!exfat_read_full(exfat->blk_dev->dev_fd, dest_bd->buffer, iter->read_size,
+			exfat_c2o(exfat, clu) + offset))
 		return -EIO;
 
 out:
@@ -906,14 +905,14 @@ static int exfat_write_dentry_set(struct exfat *exfat,
 		sec_half_off = exfat_c2o(exfat, next_clus);
 	}
 
-	if (exfat_write(exfat->blk_dev->dev_fd, dset, first_half_len,
-			first_half_off) != (ssize_t)first_half_len)
+	if (!exfat_write_full(exfat->blk_dev->dev_fd, dset, first_half_len,
+			first_half_off))
 		return -EIO;
 
 	if (sec_half_len) {
 		dset = (struct exfat_dentry *)((char *)dset + first_half_len);
-		if (exfat_write(exfat->blk_dev->dev_fd, dset, sec_half_len,
-				sec_half_off) != (ssize_t)sec_half_len)
+		if (!exfat_write_full(exfat->blk_dev->dev_fd, dset, sec_half_len,
+				sec_half_off))
 			return -EIO;
 	}
 

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -230,14 +230,89 @@ out:
 	return ret;
 }
 
-ssize_t exfat_read(int fd, void *buf, size_t size, off_t offset)
+ssize_t exfat_read(int fd, void *buf, size_t size_in, off_t offset)
 {
-	return pread(fd, buf, size, offset);
+	int ret;
+	off_t size = size_in;
+
+	if (size > SSIZE_MAX)
+		size = SSIZE_MAX;
+
+	ret = exfat_read2(fd, buf, &size, &offset);
+	if (ret < 0)
+		return ret;
+	return size_in - (size_t)size;
 }
 
-ssize_t exfat_write(int fd, void *buf, size_t size, off_t offset)
+int exfat_read2(int fd, void *buf, off_t *size, off_t *offset)
 {
-	return pwrite(fd, buf, size, offset);
+	uint8_t *m = buf;
+	size_t rem;
+	ssize_t size_read;
+
+	while (*size > 0) {
+		rem = (size_t)MIN(*size, SSIZE_MAX);
+
+		size_read = *offset >= 0 ?
+			pread(fd, m, rem, *offset) :
+			read(fd, m, rem);
+		if (size_read == 0)
+			return 1;
+		if (size_read < 0)
+			return -errno;
+		assert((size_t)size_read <= rem);
+
+		m += size_read;
+		*size -= size_read;
+		if (*offset >= 0)
+			*offset += size_read;
+	}
+
+	return 0;
+}
+
+ssize_t exfat_write(int fd, const void *buf, size_t size_in, off_t offset)
+{
+	int ret;
+	off_t size = size_in;
+
+	if (size > SSIZE_MAX)
+		size = SSIZE_MAX;
+
+	ret = exfat_write2(fd, buf, &size, &offset);
+	if (ret)
+		return ret;
+	return size_in - (size_t)size;
+}
+
+int exfat_write2(int fd, const void *buf, off_t *size, off_t *offset)
+{
+	const uint8_t *m = buf;
+	size_t rem;
+	ssize_t size_written;
+
+	while (*size > 0) {
+		rem = (size_t)MIN(*size, SSIZE_MAX);
+
+		size_written = *offset >= 0 ?
+			pwrite(fd, m, rem, *offset) :
+			write(fd, m, rem);
+		if (size_written == 0) {
+			/* the dark corner of POSIX: we mirror glibc's defence mechanism here */
+			exfat_debug("pwrite() returned zero. This VFS is doing something fishy!");
+			return -EIO;
+		}
+		if (size_written < 0)
+			return -errno;
+		assert((size_t)size_written <= rem);
+
+		m += size_written;
+		*size -= size_written;
+		if (*offset >= 0)
+			*offset += size_written;
+	}
+
+	return 0;
 }
 
 int exfat_write_zero(int fd, off_t size, off_t offset)
@@ -250,19 +325,23 @@ int exfat_write_zero2(int fd, off_t size, off_t offset, size_t bs)
 	bool mapped = false;
 	const void *zm;
 	int ret = 0;
+	size_t iter_size;
+	ssize_t wsize;
 
 	if (bs == 0)
 		bs = 4 * KB;
-
-	assert((off_t)bs > 0);
 
 	zm = exfat_map_zeromem(bs, &mapped);
 	if (zm == NULL)
 		return -errno;
 
 	while (size > 0) {
-		const size_t iter_size = MIN(size, (off_t)bs);
-		const ssize_t wsize = pwrite(fd, zm, iter_size, offset);
+		iter_size = (size_t)MIN(size, SSIZE_MAX);
+		iter_size = MIN(iter_size, bs);
+
+		wsize = offset >= 0 ?
+			pwrite(fd, zm, iter_size, offset) :
+			write(fd, zm, iter_size);
 
 		if (wsize <= 0) {
 			ret = -EIO;
@@ -270,7 +349,8 @@ int exfat_write_zero2(int fd, off_t size, off_t offset, size_t bs)
 		}
 
 		size -= wsize;
-		offset += wsize;
+		if (offset >= 0)
+			offset += wsize;
 	}
 
 out:

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -374,7 +374,7 @@ int exfat_write_zero2(int fd, off_t size, off_t offset, size_t bs)
 	}
 
 out:
-	exfat_unmap_zeromem(zm, bs, &mapped);
+	exfat_unmap_mm(zm, bs, &mapped);
 	return ret;
 }
 
@@ -905,7 +905,7 @@ int exfat_check_written_data(struct exfat_blk_dev *bd,
 
 out:
 	free(verify);
-	exfat_unmap_zeromem(zm, len, &zmapped);
+	exfat_unmap_mm(zm, len, &zmapped);
 	return ret;
 }
 
@@ -931,7 +931,7 @@ void exfat_close_fd_devzero(void)
 	fd_devzero = -1;
 }
 
-const void *exfat_map_zeromem(const size_t len, bool *mapped)
+static void *exfat_do_map_zerodev(const size_t len, bool *mapped, int prot, int flags)
 {
 	void *ret;
 
@@ -940,7 +940,8 @@ const void *exfat_map_zeromem(const size_t len, bool *mapped)
 
 #ifdef _POSIX_MAPPED_FILES
 	if (fd_devzero >= 0) {
-		ret = mmap(NULL, len, PROT_READ, MAP_SHARED, fd_devzero, 0);
+		assert(prot > 0 && flags > 0);
+		ret = mmap(NULL, len, prot, flags, fd_devzero, 0);
 
 		assert(ret != NULL);
 		if (ret != MAP_FAILED) {
@@ -964,13 +965,38 @@ const void *exfat_map_zeromem(const size_t len, bool *mapped)
 	return ret;
 }
 
-int exfat_unmap_zeromem(const void *m, const size_t len, const bool *mapped)
+const void *exfat_map_zeromem(const size_t len, bool *mapped)
+{
+	int prot = -1;
+	int flags = -1;
+
+#ifdef _POSIX_MAPPED_FILES
+	prot = PROT_READ;
+	flags = MAP_SHARED;
+#endif
+	return exfat_do_map_zerodev(len, mapped, prot, flags);
+}
+
+void *exfat_map_blankmem(const size_t len, bool *mapped)
+{
+	int prot = -1;
+	int flags = -1;
+
+#ifdef _POSIX_MAPPED_FILES
+	prot = PROT_READ|PROT_WRITE;
+	flags = MAP_PRIVATE;
+#endif
+	return exfat_do_map_zerodev(len, mapped, prot, flags);
+}
+
+int exfat_unmap_mm(const void *m, const size_t len, bool *mapped)
 {
 	if (m == NULL)
 		return 0;
 
 #ifdef _POSIX_MAPPED_FILES
 	if (*mapped) {
+		*mapped = false;
 		if (len > 0)
 			return munmap((void *)m, len);
 		return 0;

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -271,6 +271,13 @@ int exfat_read2(int fd, void *buf, off_t *size, off_t *offset)
 	return 0;
 }
 
+bool exfat_read_full(int fd, void *buf, size_t size, off_t offset)
+{
+	const ssize_t ret = exfat_read(fd, buf, size, offset);
+
+	return ret >= 0 && (size_t)ret == size;
+}
+
 ssize_t exfat_write(int fd, const void *buf, size_t size_in, off_t offset)
 {
 	int ret;
@@ -313,6 +320,13 @@ int exfat_write2(int fd, const void *buf, off_t *size, off_t *offset)
 	}
 
 	return 0;
+}
+
+bool exfat_write_full(int fd, const void *buf, size_t size, off_t offset)
+{
+	const ssize_t ret = exfat_write(fd, buf, size, offset);
+
+	return ret >= 0 && (size_t)ret == size;
 }
 
 int exfat_write_zero(int fd, off_t size, off_t offset)
@@ -500,7 +514,7 @@ ssize_t exfat_utf16_dec(const __u16 *in_str, size_t in_len,
 off_t exfat_get_root_entry_offset(struct exfat_blk_dev *bd)
 {
 	struct pbr *bs;
-	int nbytes;
+	bool ret;
 	unsigned int cluster_size, sector_size;
 	off_t root_clu_off;
 
@@ -510,8 +524,8 @@ off_t exfat_get_root_entry_offset(struct exfat_blk_dev *bd)
 		return -ENOMEM;
 	}
 
-	nbytes = exfat_read(bd->dev_fd, bs, EXFAT_MAX_SECTOR_SIZE, 0);
-	if (nbytes != EXFAT_MAX_SECTOR_SIZE) {
+	ret = exfat_read_full(bd->dev_fd, bs, EXFAT_MAX_SECTOR_SIZE, 0);
+	if (!ret) {
 		exfat_err("boot sector read failed: %d\n", errno);
 		free(bs);
 		return -1;
@@ -835,15 +849,8 @@ int exfat_check_written_data(struct exfat_blk_dev *bd,
 	void *verify = NULL;
 	const void *zm = NULL;
 	bool zmapped = false;
-	ssize_t n;
 	int ret = 0;
 
-	/*
-	 * See read(2) for max return value of read(). Well, if we wanna
-	 * support more than this, exfat_read() should be done in a
-	 * loop.
-	 */
-	assert(len <= 0x7FFFF000);
 	assert(sector > 0);
 
 	if (len == 0)
@@ -853,12 +860,12 @@ int exfat_check_written_data(struct exfat_blk_dev *bd,
 	if (ret)
 		return ret;
 
-	const off_t aligned_off = off & ~((off_t)sector - 1); /* this is evil */
-	const off_t head = off - aligned_off;
-	const off_t aligned_len = ((head + len + sector - 1) / sector) * sector;
+	off_t aligned_off = off & ~((off_t)sector - 1); /* this is evil */
+	off_t head = off - aligned_off;
+	off_t aligned_len = ((head + len + sector - 1) / sector) * sector;
 
 	assert(head >= 0 && head < (off_t)sector);
-	assert(aligned_len > 0 && aligned_len <= 0x7FFFF000 && aligned_len >= (off_t)len);
+	assert(aligned_len > 0 && aligned_len >= (off_t)len);
 
 	if (posix_memalign(&verify, sector, (size_t)aligned_len))
 		return -errno;
@@ -874,11 +881,11 @@ int exfat_check_written_data(struct exfat_blk_dev *bd,
 		buf = zm;
 	}
 
-	n = exfat_read(bd->verify_fd, verify, (size_t)aligned_len, aligned_off);
-	if (n != (ssize_t)aligned_len) {
-		exfat_debug("%s verify read failed (off=%llu, len=%zu)\n",
-					what, (unsigned long long)aligned_off,
-					(size_t)aligned_len);
+	ret = exfat_read2(bd->verify_fd, verify, &aligned_len, &aligned_off);
+	if (ret) {
+		exfat_debug("%s verify read failed (off=%llu, len=%llu)\n", what,
+				(unsigned long long)aligned_off,
+				(unsigned long long)aligned_len);
 		ret = -EIO;
 		goto out;
 	}
@@ -973,12 +980,10 @@ int exfat_unmap_zeromem(const void *m, const size_t len, const bool *mapped)
 
 int exfat_read_sector(struct exfat_blk_dev *bd, void *buf, unsigned int sec_off)
 {
-	int ret;
 	unsigned long long offset =
 		(unsigned long long)sec_off * bd->sector_size;
 
-	ret = pread(bd->dev_fd, buf, bd->sector_size, offset);
-	if (ret < 0) {
+	if (!exfat_read_full(bd->dev_fd, buf, bd->sector_size, offset)) {
 		exfat_err("read failed, sec_off : %u\n", sec_off);
 		return -1;
 	}
@@ -988,14 +993,11 @@ int exfat_read_sector(struct exfat_blk_dev *bd, void *buf, unsigned int sec_off)
 int exfat_write_sector(struct exfat_blk_dev *bd, void *buf,
 		unsigned int sec_off)
 {
-	int bytes;
 	unsigned long long offset =
 		(unsigned long long)sec_off * bd->sector_size;
 
-	bytes = pwrite(bd->dev_fd, buf, bd->sector_size, offset);
-	if (bytes != (int)bd->sector_size) {
-		exfat_err("write failed, sec_off : %u, bytes : %d\n", sec_off,
-			bytes);
+	if (!exfat_write_full(bd->dev_fd, buf, bd->sector_size, offset)) {
+		exfat_err("write failed, sec_off : %u\n", sec_off);
 		return -1;
 	}
 	return 0;
@@ -1047,7 +1049,7 @@ free:
 int exfat_show_volume_serial(int fd)
 {
 	struct pbr *ppbr;
-	int ret;
+	int ret = 0;
 
 	ppbr = malloc(EXFAT_MAX_SECTOR_SIZE);
 	if (!ppbr) {
@@ -1056,8 +1058,7 @@ int exfat_show_volume_serial(int fd)
 	}
 
 	/* read main boot sector */
-	ret = exfat_read(fd, (char *)ppbr, EXFAT_MAX_SECTOR_SIZE, 0);
-	if (ret < 0) {
+	if (!exfat_read_full(fd, (char *)ppbr, EXFAT_MAX_SECTOR_SIZE, 0)) {
 		exfat_err("main boot sector read failed\n");
 		ret = -1;
 		goto free_ppbr;
@@ -1130,9 +1131,7 @@ int exfat_set_volume_serial(struct exfat_blk_dev *bd,
 	}
 
 	/* read main boot sector */
-	ret = exfat_read(bd->dev_fd, (char *)ppbr, EXFAT_MAX_SECTOR_SIZE,
-			BOOT_SEC_IDX);
-	if (ret < 0) {
+	if (!exfat_read_full(bd->dev_fd, (char *)ppbr, EXFAT_MAX_SECTOR_SIZE, BOOT_SEC_IDX)) {
 		exfat_err("main boot sector read failed\n");
 		ret = -1;
 		goto free_ppbr;
@@ -1200,8 +1199,7 @@ int exfat_get_next_clus(struct exfat *exfat, clus_t clus, clus_t *next)
 				exfat->bs->bsx.sect_size_bits;
 	offset += sizeof(clus_t) * clus;
 
-	if (exfat_read(exfat->blk_dev->dev_fd, next, sizeof(*next), offset)
-			!= sizeof(*next))
+	if (!exfat_read_full(exfat->blk_dev->dev_fd, next, sizeof(*next), offset))
 		return -EIO;
 	*next = le32_to_cpu(*next);
 	return 0;
@@ -1256,8 +1254,7 @@ int exfat_set_fat(struct exfat *exfat, clus_t clus, clus_t next_clus)
 
 	next_clus = cpu_to_le32(next_clus);
 
-	if (exfat_write(exfat->blk_dev->dev_fd, &next_clus, sizeof(next_clus),
-			offset) != sizeof(next_clus))
+	if (!exfat_write_full(exfat->blk_dev->dev_fd, &next_clus, sizeof(next_clus), offset))
 		return -EIO;
 	return 0;
 }
@@ -1343,8 +1340,7 @@ int read_boot_sect(struct exfat_blk_dev *bdev, struct pbr **bs)
 		return -ENOMEM;
 	}
 
-	if (exfat_read(bdev->dev_fd, pbr, sizeof(*pbr), 0) !=
-	    (ssize_t)sizeof(*pbr)) {
+	if (!exfat_read_full(bdev->dev_fd, pbr, sizeof(*pbr), 0)) {
 		exfat_err("failed to read a boot sector\n");
 		err = -EIO;
 		goto err;

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -197,10 +197,16 @@ int exfat_get_blk_dev_info(struct exfat_user_input *ui,
 	if (!ui->boundary_align)
 		ui->boundary_align = DEFAULT_BOUNDARY_ALIGNMENT;
 
+	bd->dev_sector_size = 0;
+	if (ioctl(fd, BLKSSZGET, &bd->dev_sector_size) < 0)
+		bd->dev_sector_size = 0;
+
 	if (ui->sector_size)
 		bd->sector_size = ui->sector_size;
-	else if (ioctl(fd, BLKSSZGET, &bd->sector_size) < 0)
+	else if (bd->dev_sector_size == 0)
 		bd->sector_size = DEFAULT_SECTOR_SIZE;
+	else
+		bd->sector_size = bd->dev_sector_size;
 	bd->sector_size_bits = sector_size_bits(bd->sector_size);
 	bd->num_sectors = blk_dev_size / bd->sector_size;
 	bd->num_clusters = blk_dev_size / ui->cluster_size;

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -128,9 +128,9 @@ static inline unsigned int sector_size_bits(unsigned int size)
 static void exfat_set_default_cluster_size(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
-	if (256 * MB >= bd->size)
+	if (256ULL * MB >= bd->size)
 		ui->cluster_size = 4 * KB;
-	else if (32 * GB >= bd->size)
+	else if (32ULL * GB >= bd->size)
 		ui->cluster_size = 32 * KB;
 	else
 		ui->cluster_size = 128 * KB;

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -87,6 +87,9 @@ The \fIsize\fR argument is specified in bytes or may be specified with
 bytes.
 The default value is the sector size reported by the device, or 512 bytes if the
 device sector size cannot be determined.
+An exFAT volume formatted with the sector size value other than that of the
+device is unusable in most operating systems. \fBDO NOT use this option\fR
+unless you're absolutely sure that you know what you're doing.
 .TP
 .BR \-c ", " \-\-cluster\-size =\fIsize\fR
 Specifies the cluster size of the exFAT file system.

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -398,34 +398,40 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
 {
 	char *bitmap;
-	unsigned int full_bytes, rem_bits, zero_offset;
+	unsigned int full_bytes, rem_bits;
 	int ret = 0;
+	bool mapped = false;
 
-	bitmap = malloc(finfo.bitmap_byte_len);
-	if (!bitmap) {
+	bitmap = exfat_map_blankmem(finfo.bitmap_byte_len, &mapped);
+	if (bitmap == NULL) {
 		exfat_err("Cannot allocate bitmap: out of memory\n");
 		return -1;
 	}
+#if defined(__linux__) || defined(__FreeBSD__)
+	/*
+	 * Demand paging off /dev/zero is extremely a Linux/FreeBSD thing.
+	 * This code path is not tested at the time of writing because
+	 * exfatprogs is only supported on Linux(might work on FreeBSD
+	 * on top of the compat ABI mode).
+	 */
+	if (!mapped)
+		exfat_info("mmap() for bitmap failed: errno=%d. Falling back to allocating memory.\n"
+			   "Up to %u bytes of memory may be required.\n",
+			   errno, finfo.bitmap_byte_len);
+#endif
 
 	full_bytes = finfo.used_clu_cnt / 8;
 	rem_bits = finfo.used_clu_cnt % 8;
-	zero_offset = full_bytes;
 
 	memset(bitmap, 0xff, full_bytes);
 
-	if (rem_bits != 0) {
+	if (rem_bits != 0)
 		bitmap[full_bytes] = (1 << rem_bits) - 1;
-		++zero_offset;
-	}
-
-	if (zero_offset < finfo.bitmap_byte_len)
-		memset(bitmap + zero_offset, 0, finfo.bitmap_byte_len - zero_offset);
-
 
 	if (!exfat_write_full(bd->dev_fd, bitmap, finfo.bitmap_byte_len, finfo.bitmap_byte_off)) {
 		exfat_err("write failed, bitmap_len : %d\n", finfo.bitmap_byte_len);
-		free(bitmap);
-		return -1;
+		ret = -1;
+		goto out;
 	}
 
 	if (ui->verify) {
@@ -435,13 +441,13 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd,
 				"bitmap");
 		if (ret) {
 			exfat_err("bitmap verification failed (read-back mismatch)\n");
-			free(bitmap);
-			return ret;
+			goto out;
 		}
 	}
 
-	free(bitmap);
-	return 0;
+out:
+	exfat_unmap_mm(bitmap, finfo.bitmap_byte_len, &mapped);
+	return ret;
 }
 
 static int exfat_create_root_dir(struct exfat_blk_dev *bd,
@@ -836,7 +842,7 @@ static int exfat_zero_out_disk(struct exfat_blk_dev *bd,
 	}
 
 out:
-	exfat_unmap_zeromem(zm, iosize, &mapped);
+	exfat_unmap_mm(zm, iosize, &mapped);
 
 	if (ret)
 		exfat_err("write failed(errno : %d)\n", errno);

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -1108,6 +1108,27 @@ int main(int argc, char *argv[])
 	ret = exfat_get_blk_dev_info(&ui, &bd);
 	if (ret < 0)
 		goto out;
+	if (!quiet && ui.sector_size) {
+		exfat_info(
+			"!!! Use -s option only if you know what you're doing !!!\n"
+			"There are legitimate use cases for this option, but you really should be fixing\n"
+			"the underlying hardware issue rather than overriding the sector size to force\n"
+			"things to work!\n"
+		);
+
+		if (bd.dev_sector_size && bd.dev_sector_size != ui.sector_size) {
+			/*
+			 * The user supplied the sector size(-b option) and it doesn't match up with
+			 * that of the device the kernel reported.
+			 *
+			 * Linux kernel exFAT is able to handle it by increasing the logical sector
+			 * size of the blockdev, but other implementations are not as sophisticated.
+			 */
+			exfat_info("!!! Sector size mismatch: requested=%u, dev=%u !!!\n",
+				   ui.sector_size, bd.dev_sector_size);
+			exfat_info("!!! The volume will be unusable in many operating systems !!!\n");
+		}
+	}
 
 	ret = exfat_build_mkfs_info(&bd, &ui);
 	if (ret)

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -980,7 +980,7 @@ int main(int argc, char *argv[])
 {
 	int c;
 	int ret = EXIT_FAILURE;
-	struct exfat_blk_dev bd;
+	struct exfat_blk_dev bd = { 0, };
 	struct exfat_user_input ui;
 	bool version_only = false;
 	bool quiet = false;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -285,11 +285,9 @@ static int exfat_create_volume_boot_record(struct exfat_blk_dev *bd,
 static int write_fat_entry(struct exfat_user_input *ui, int fd,
 		__le32 clu, unsigned long long offset)
 {
-	int nbyte;
 	off_t fat_entry_offset = finfo.fat_byte_off + (offset * sizeof(__le32));
 
-	nbyte = pwrite(fd, (__u8 *) &clu, sizeof(__le32), fat_entry_offset);
-	if (nbyte != sizeof(int)) {
+	if (!exfat_write_full(fd, (__u8 *) &clu, sizeof(__le32), fat_entry_offset)) {
 		exfat_err("write failed, offset : %llu, clu : %x\n",
 			offset, clu);
 		return -1;
@@ -401,7 +399,6 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd,
 {
 	char *bitmap;
 	unsigned int full_bytes, rem_bits, zero_offset;
-	unsigned int nbytes;
 	int ret = 0;
 
 	bitmap = malloc(finfo.bitmap_byte_len);
@@ -425,10 +422,8 @@ static int exfat_create_bitmap(struct exfat_blk_dev *bd,
 		memset(bitmap + zero_offset, 0, finfo.bitmap_byte_len - zero_offset);
 
 
-	nbytes = pwrite(bd->dev_fd, bitmap, finfo.bitmap_byte_len, finfo.bitmap_byte_off);
-	if (nbytes != finfo.bitmap_byte_len) {
-		exfat_err("write failed, nbytes : %d, bitmap_len : %d\n",
-			nbytes, finfo.bitmap_byte_len);
+	if (!exfat_write_full(bd->dev_fd, bitmap, finfo.bitmap_byte_len, finfo.bitmap_byte_off)) {
+		exfat_err("write failed, bitmap_len : %d\n", finfo.bitmap_byte_len);
 		free(bitmap);
 		return -1;
 	}
@@ -454,7 +449,7 @@ static int exfat_create_root_dir(struct exfat_blk_dev *bd,
 {
 	struct exfat_dentry ed[4] = {0};
 	int dentries_len = sizeof(ed);
-	int nbytes, ret;
+	int ret;
 
 	ret = exfat_write_zero2(bd->dev_fd, ui->cluster_size,
 			finfo.root_byte_off, ui->cluster_size);
@@ -504,10 +499,8 @@ static int exfat_create_root_dir(struct exfat_blk_dev *bd,
 		ed[3].upcase_size = cpu_to_le64(finfo.ut_byte_len);
 	}
 
-	nbytes = pwrite(bd->dev_fd, ed, dentries_len, finfo.root_byte_off);
-	if (nbytes != dentries_len) {
-		exfat_err("write failed, nbytes : %d, dentries_len : %d\n",
-			nbytes, dentries_len);
+	if (!exfat_write_full(bd->dev_fd, ed, dentries_len, finfo.root_byte_off)) {
+		exfat_err("write failed, dentries_len : %d\n", dentries_len);
 		return -1;
 	}
 
@@ -620,7 +613,8 @@ static int exfat_load_upcase(struct exfat_user_input *ui)
 	uint8_t *m = NULL;
 	void *nm;
 	off_t len;
-	size_t buflen = 0, size = 0;
+	size_t size = 0;
+	ssize_t rlen;
 
 	if (!exfat_ui_has_upcase_file(ui)) {
 		/* set defaults and return */
@@ -672,41 +666,27 @@ static int exfat_load_upcase(struct exfat_user_input *ui)
 	if (m == NULL)
 		goto nomem;
 
-	lseek(fd, 0, SEEK_SET);
-
-	while (true) {
-		const size_t rem = size - buflen;
-		ssize_t rsize;
-
-		rsize = read(fd, m + buflen, rem);
-		if (rsize == 0)
-			break;
-		if (rsize < 0) {
-			ret = -errno;
-			goto free;
-		}
-
-		buflen += rsize;
-		if (buflen > EXFAT_MAX_UPCASE_TABLE_SIZE) {
-			ret = -EFBIG;
-			goto free;
-		}
-		if (len > 0 && buflen >= (size_t)len)
-			break;
+	rlen = exfat_read(fd, m, size, 0);
+	if (rlen < 0) {
+		ret = -errno;
+		goto free;
+	} else if ((size_t)rlen > EXFAT_MAX_UPCASE_TABLE_SIZE) {
+		ret = -EFBIG;
+		goto free;
 	}
 
 	/* shrink to fit before returning, ignoring errors */
-	if (buflen == 0) {
+	if (rlen == 0) {
 		free(m);
 		m = NULL;
-	} else if (buflen != size) {
-		nm = realloc(m, buflen);
+	} else if ((size_t)rlen != size) {
+		nm = realloc(m, rlen);
 		if (nm != NULL)
 			m = nm;
 	}
 
 	ui->upcase.table = ui->upcase.m = m;
-	ui->upcase.len = buflen;
+	ui->upcase.len = rlen;
 	ui->upcase.free = exfat_free_upcase_m;
 	goto out;
 

--- a/mkfs/upcase.c
+++ b/mkfs/upcase.c
@@ -18,19 +18,11 @@ int exfat_create_upcase_table(struct exfat_blk_dev *bd,
 {
 	off_t zero_ofs;
 	off_t zero_len;
-	ssize_t nbytes;
 	int ret;
 
 	assert(finfo.root_byte_off >= finfo.ut_byte_off);
 
-	/*
-	 * FIXME bytes written in [p]write() may be less than requested len.
-	 * This won't work if the table is large enough.
-	 *
-	 * TODO do this in a loop.
-	 */
-	nbytes = pwrite(bd->dev_fd, ui->upcase.table, ui->upcase.len, finfo.ut_byte_off);
-	if (nbytes != (ssize_t)ui->upcase.len)
+	if (!exfat_write_full(bd->dev_fd, ui->upcase.table, ui->upcase.len, finfo.ut_byte_off))
 		return -1;
 	if (ui->verify) {
 		ret = exfat_check_written_data(bd,

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
 	int c;
 	int ret = EXIT_FAILURE;
 	unsigned long volume_serial;
-	struct exfat_blk_dev bd;
+	struct exfat_blk_dev bd = { 0, };
 	struct exfat_user_input ui;
 	bool version_only = false;
 	int flags = 0;

--- a/upcase/Makefile.am
+++ b/upcase/Makefile.am
@@ -1,20 +1,7 @@
 upcase_bin_DATA = \
-	upcase-mandatory.txt		\
-	upcase-recommended.txt		\
-	upcase-null.txt			\
-	upcase-mandatory.bin		\
-	upcase-recommended.bin		\
-	upcase-null.bin
+	$(top_srcdir)/upcase/upcase-mandatory.txt	\
+	$(top_srcdir)/upcase/upcase-null.txt		\
+	$(top_srcdir)/upcase/upcase-recommended.txt
 
 libexec_SCRIPTS = exfat-uctbl2bin.sh
 upcase_bindir = $(docdir)
-
-upcase-mandatory.bin: exfat-uctbl2bin.sh upcase-mandatory.txt
-	./exfat-uctbl2bin.sh upcase-mandatory.txt > upcase-mandatory.tmp
-	mv upcase-mandatory.tmp upcase-mandatory.bin
-upcase-recommended.bin: exfat-uctbl2bin.sh upcase-recommended.txt
-	./exfat-uctbl2bin.sh upcase-recommended.txt > upcase-recommended.tmp
-	mv upcase-recommended.tmp upcase-recommended.bin
-upcase-null.bin: exfat-uctbl2bin.sh upcase-null.txt
-	./exfat-uctbl2bin.sh upcase-null.txt > upcase-null.tmp
-	mv upcase-null.tmp upcase-null.bin


### PR DESCRIPTION
Fixes:

 - https://github.com/exfatprogs/exfatprogs/pull/341#discussion_r3114896378

Addresses:

 - #349 
 - #347

Fixes some minor bugs introduced in:

 - #346
 - #341 

https://github.com/dxdxdt/exfatprogs/actions/runs/24894097359

---

```
David Timber (8):
  upcase: simplify and fix Makefile.am
  mkfs: fix incorrect default cluster size selection due to overflow
  Github workflow: test building from a separate build directory
  Github workflow: fix intermittent Windows runner failure
  Recover from premature completion of [p]read|write()
  Refactor I/O handling
  mkfs: warn if -s option is used
  mkfs: reduce RSS memory footprint for huge bitmap

 .github/workflows/c-cpp.yml |  21 +++-
 defrag/defrag.c             |  30 ++---
 dump/dump.c                 |   7 +-
 exfat2img/exfat2img.c       |  38 ++++---
 fsck/fsck.c                 |  68 +++++------
 include/libexfat.h          |  56 ++++++++-
 lib/exfat_dir.c             |  17 ++-
 lib/libexfat.c              | 220 +++++++++++++++++++++++++++---------
 manpages/mkfs.exfat.8       |   3 +
 mkfs/mkfs.c                 | 121 ++++++++++----------
 mkfs/upcase.c               |  10 +-
 upcase/Makefile.am          |  25 ++--
 12 files changed, 385 insertions(+), 231 deletions(-)

-- 
2.53.0.1.ga224b40d3f.dirty
```