### PR TITLE
mkfs: improve foreign filesystem detection

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -26,6 +26,20 @@ env:
   TEST_MAGIC: dd01aeee-bab0-babe-babe-deadcafebeef
 
   UTIL_LINUX_SRC: https://www.kernel.org/pub/linux/utils/util-linux/v2.42/util-linux-2.42.tar.xz
+  # xfstests generic/740 equiv
+  FOREIGN_FS: |
+    (
+      "mkfs.exfat img"
+      "mkfs.fat img"
+      "mkfs.ext4 img"
+      "mkfs.btrfs img"
+      "mkfs.f2fs img"
+      "mkfs.ntfs -QF img"
+      "mkfs.xfs img"
+      "echo -e 'YES\n1234' | cryptsetup luksFormat --force-password img"
+      "parted img mkt msdos"
+      "parted img mkt gpt"
+    )
 
 jobs:
   memcheck:
@@ -154,6 +168,7 @@ jobs:
       run: |
         sudo apt-get --update --quiet --yes install \
              linux-headers-$(uname -r) xz-utils curl \
+             cryptsetup parted dosfstools e2fsprogs btrfs-progs f2fs-tools ntfs-3g xfsprogs \
              ${{ matrix.gcc }} ${{ matrix.qemu }} \
              qemu-user qemu-utils
         sudo apt-get install -y linux-modules-extra-$(uname -r)
@@ -202,6 +217,35 @@ jobs:
       run: |
         ./configure --host=${{ matrix.host }}
         make -j$((`nproc`+1))
+
+    - name: Test foreign filesystem detection
+      env:
+        EXFAT_TTY_OVERRIDE: 1
+      shell: bash
+      run: |
+        set -e
+
+        EXFAT_MKFS="$(realpath ./mkfs/mkfs.exfat)"
+
+        pushd "$(mktemp -d)"
+
+        declare -a arr=${{ env.FOREIGN_FS }}
+        for fs_cmd in "${arr[@]}"
+        do
+          truncate -s 0 img && truncate -s 1G img
+          echo === $fs_cmd ===
+          eval $fs_cmd
+
+          if "$EXFAT_MKFS" img
+          then
+            echo "mkfs.exfat overwrote existing fs !!!" >&2
+            exit 1
+          fi
+        done
+
+        rm -rf "$(realpath .)"
+        popd
+
     - name: run fsck repair testcases
       run: |
         pushd tests

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -25,6 +25,8 @@ env:
     1T 2T 3T 4T 6T 8T 16T 32T 44T 64T
   TEST_MAGIC: dd01aeee-bab0-babe-babe-deadcafebeef
 
+  UTIL_LINUX_SRC: https://www.kernel.org/pub/linux/utils/util-linux/v2.42/util-linux-2.42.tar.xz
+
 jobs:
   memcheck:
     runs-on: ubuntu-latest
@@ -38,7 +40,7 @@ jobs:
       run: |
         sudo apt-get --update --quiet --yes install \
              linux-headers-$(uname -r) xz-utils \
-             valgrind ${{ matrix.cc }}
+             valgrind libblkid-dev ${{ matrix.cc }}
         sudo apt-get install -y linux-modules-extra-$(uname -r)
     - name: Build
       run: |
@@ -148,16 +150,35 @@ jobs:
             run:  qemu-i386
             name: i686
     steps:
-    - uses: actions/checkout@v6
     - name: Install packages
       run: |
         sudo apt-get --update --quiet --yes install \
-             linux-headers-$(uname -r) xz-utils \
+             linux-headers-$(uname -r) xz-utils curl \
              ${{ matrix.gcc }} ${{ matrix.qemu }} \
              qemu-user qemu-utils
         sudo apt-get install -y linux-modules-extra-$(uname -r)
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
         export PATH=/usr/local/lib:$PATH
+    - name: Build libblkid
+      shell: bash
+      run: |
+        set -e
+        curl "$UTIL_LINUX_SRC" | xzcat | tar xf -
+        pushd util-linux-*
+
+        ./configure --host=${{ matrix.host }} --prefix=/usr/${{ matrix.host }}/local \
+          --disable-shared --enable-static --disable-all-programs --enable-libblkid
+        make -j$((`nproc`+1))
+        sudo make -j$((`nproc`+1)) install
+        make -j$((`nproc`+1)) distclean
+
+        ./configure --disable-all-programs --enable-libblkid
+        make -j$((`nproc`+1))
+        sudo make -j$((`nproc`+1)) install
+
+        rm -rf "$(realpath .)"
+        popd
+    - uses: actions/checkout@v6
     - name: Bootstrap build system
       run: ./autogen.sh
     - name: Test building exfatprogs on arbitrary directory
@@ -175,8 +196,11 @@ jobs:
 
         rm -rf "$BUILD_DIR"
     - name: Build exfatprogs for test target
+      env:
+        CFLAGS: --static
+        PKG_CONFIG_PATH: /usr/${{ matrix.host }}/local/lib/pkgconfig
       run: |
-        ./configure --host=${{ matrix.host }} CFLAGS=--static
+        ./configure --host=${{ matrix.host }}
         make -j$((`nproc`+1))
     - name: run fsck repair testcases
       run: |

--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -16,9 +16,12 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Packages
-        run: apk --update add alpine-sdk autoconf libtool automake linux-headers bash xxd xz
+        run: |
+          apk --update add \
+            alpine-sdk autoconf libtool automake linux-headers bash xxd xz \
+            util-linux-dev
       - name: Autoconf and Configure
         run: ./autogen.sh && ./configure
       - name: Build
@@ -34,12 +37,12 @@ jobs:
     container:
       image: debian:unstable
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Packages
         run: |
           apt-get --update --quiet --yes install \
             clang lld pkgconf xxd autoconf \
-            libtool automake make xz-utils
+            libtool automake make xz-utils libblkid-dev
       - name: Autoconf and Configure
         run: |
           export LDFLAGS="-fuse-ld=lld"

--- a/configure.ac
+++ b/configure.ac
@@ -44,17 +44,11 @@ AM_COND_IF(
 	[echo "<fts.h> not found. Not building dosattr programs"]
 )
 
-PKG_CHECK_MODULES([BLKID], [blkid >= 2.20],
-	[
-		AC_DEFINE([HAVE_LIBBLKID], [1], [Define to 1 if libblkid is available.])
-	],
-	[
-		BLKID_CFLAGS=
-		BLKID_LIBS=
-		AC_MSG_WARN([libblkid not found or too old; foreign filesystem detection in mkfs.exfat will be disabled])
-	]
-)
-AC_SUBST([BLKID_CFLAGS])
-AC_SUBST([BLKID_LIBS])
+# There are two variants of libblkid: one from util-linux and the other from
+# e2fsprogs. In Android(AOSP), only the e2fsprogs variant is available.
+# Most distros don't provide a static libblkid so in order to build static
+# executables, libblkid.a will have to be built first.
+PKG_CHECK_MODULES([BLKID], [blkid >= 2.20], [AC_DEFINE([HAVE_BLKID], [1], [Define if libblkid is from util-linux])],
+	[PKG_CHECK_MODULES([EXT2_BLKID], [blkid], [AC_DEFINE([HAVE_EXT2_BLKID], [1], [Define if libblkid is from libext2])])])
 
 AC_OUTPUT

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -381,6 +381,20 @@ void exfat_put_mbr_partition(const struct exfat_blk_dev *bd, void *dst,
 void exfat_put_bootstrap_code(const char *user_msg, void *dst, unsigned int code_offset);
 
 /*
+ * Misc
+ */
+
+/*
+ * Returns true if STDIN and STDOUT are associated with a terminal. Returns
+ * false otherwise.
+ *
+ * To override the return value of this function, the influential env var
+ * EXFAT_TTY_OVERRIDE can be set to a non-negative integral value. This is for
+ * testing `mkfs.exfat -F` in xfstests and CI pipelines.
+ */
+bool exfat_isatty_stdio(void);
+
+/*
  * Exfat Print
  */
 

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -1927,3 +1927,17 @@ void exfat_put_bootstrap_code(const char *user_msg, void *dst, unsigned int code
 	}
 	/* *p = 0; */
 }
+
+bool exfat_isatty_stdio(void)
+{
+	const char *env = getenv("EXFAT_TTY_OVERRIDE");
+
+	if (env != NULL) {
+		int v = -1;
+
+		if (sscanf(env, "%d", &v) == 1 && v >= 0)
+			return v != 0;
+	}
+
+	return isatty(STDIN_FILENO) && isatty(STDOUT_FILENO);
+}

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -5,6 +5,8 @@ mkfs.exfat \- create an exFAT filesystem
 .SH SYNOPSIS
 .B mkfs.exfat
 [
+.B \-CfFKqv
+] [
 .B \-b
 .I boundary_alignment
 ] [
@@ -13,14 +15,6 @@ mkfs.exfat \- create an exFAT filesystem
 ] [
 .B \-c
 .I cluster_size
-] [
-.B \-f
-] [
-.B \-F
-] [
-.B \-C
-] [
-.B \-h
 ] [
 .B \-L
 .I volume_label
@@ -34,12 +28,12 @@ mkfs.exfat \- create an exFAT filesystem
 .B \-\-pack\-bitmap
 ] [
 .B \-\-upcase\fR=\fIfile\fR
-] [
-.B \-v
 ]
 .I device
 .br
 .B mkfs.exfat \-V
+.br
+.B mkfs.exfat \-h
 .SH DESCRIPTION
 .B mkfs.exfat
 creates an exFAT filesystem by writing on a special

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -119,11 +119,10 @@ This zeros the entire disk device while creating the exFAT filesystem.
 .TE
 .TP
 .BR \-F ", " \-\-force
-Allow overwriting a device that already contains a non-exFAT filesystem.
-Without this option, mkfs.exfat refuses to format when libblkid detects a
-foreign filesystem signature on the target device.
-This safeguard is unavailable when exfatprogs is built without libblkid
-support.
+Allow overwriting a device that already contains a disk signature. Without this
+option, mkfs.exfat refuses to format when libblkid detects a foreign disk
+signature on the target device. This safeguard is in effect only when
+\fBmkfs.exfat\fR is run from a terminal.
 .TP
 .BR \-K ", " \-\-no\-discard
 Do not attempt to discard blocks.

--- a/mkfs/Android.bp
+++ b/mkfs/Android.bp
@@ -6,7 +6,9 @@ cc_binary {
     srcs: [
         "mkfs.c",
         "upcase.c",
+        "crc.c",
     ],
     defaults: ["exfatprogs-defaults"],
     static_libs: ["libexfat"],
+    shared_libs: ["libext2_blkid"],
 }

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -22,9 +22,7 @@
 #ifdef _POSIX_MAPPED_FILES
 #include <sys/mman.h>
 #endif
-#ifdef HAVE_LIBBLKID
-#include <blkid/blkid.h>
-#endif
+#include <blkid.h>
 
 #include "exfat_ondisk.h"
 #include "libexfat.h"
@@ -1177,51 +1175,82 @@ out:
 	return ret;
 }
 
-#ifdef HAVE_LIBBLKID
-static int check_existing_filesystem(const char *dev_name, bool force)
+static int check_existing_filesystem(const struct exfat_user_input *ui, const bool quiet)
 {
-	blkid_probe probe;
-	const char *fstype = NULL;
 	int ret = 0;
+	const char *fstype = NULL, *pttype = NULL;
+#if defined(HAVE_BLKID)
+	blkid_probe probe;
 
-	probe = blkid_new_probe_from_filename(dev_name);
-	if (!probe) {
-		exfat_err("Failed to create blkid probe for %s\n", dev_name);
-		return -1;
-	}
+	probe = blkid_new_probe_from_filename(ui->dev_name);
+	if (!probe)
+		goto alloc_err;
 
 	blkid_probe_enable_superblocks(probe, 1);
 	blkid_probe_set_superblocks_flags(probe, BLKID_SUBLKS_TYPE);
+	blkid_probe_enable_partitions(probe, 1);
 
-	if (blkid_do_safeprobe(probe) == 0 &&
-	    blkid_probe_lookup_value(probe, "TYPE", &fstype, NULL) == 0 &&
-	    fstype != NULL) {
-		exfat_debug("Detected filesystem type: %s\n", fstype);
-		if (strcmp(fstype, "exfat") != 0) {
-			if (!force) {
-				exfat_err("Device %s already contains a %s filesystem. Refusing to overwrite; use -F to force.\n",
-					  dev_name, fstype);
-				ret = -1;
-			} else {
-				exfat_info("Forcing overwrite of existing %s filesystem on %s.\n",
-					   fstype, dev_name);
-			}
+	if (blkid_do_safeprobe(probe) == 0) {
+		blkid_probe_lookup_value(probe, "TYPE", &fstype, NULL);
+		blkid_probe_lookup_value(probe, "PTTYPE", &pttype, NULL);
+	}
+#else
+	/*
+	 * Polyfill for Android(libext2_blkid) and systems without util-linux for reasons unknown
+	 *
+	 * Unfortunately, this variant of libblkid may not support detection of partition tables.
+	 */
+	blkid_cache cache = NULL;
+	blkid_dev dev;
+	blkid_tag_iterate iter;
+	const char *k, *v;
+
+	if (blkid_get_cache(&cache, NULL) < 0)
+		goto alloc_err;
+
+	dev = blkid_get_dev(cache, ui->dev_name, BLKID_DEV_CREATE | BLKID_DEV_VERIFY);
+	if (dev) {
+		iter = blkid_tag_iterate_begin(dev);
+		while (blkid_tag_next(iter, &k, &v) == 0) {
+			if (strcmp("TYPE", k) == 0)
+				fstype = v;
+			else if (strcmp("PTTYPE", k) == 0)
+				pttype = v;
+
+			if (fstype && pttype)
+				break;
 		}
-	} else {
-		exfat_debug("No existing filesystem detected on %s\n", dev_name);
+		blkid_tag_iterate_end(iter);
 	}
 
-	blkid_free_probe(probe);
-	return ret;
-}
-#else
-static int check_existing_filesystem(const char *dev_name, bool force)
-{
-	(void)dev_name;
-	(void)force;
-	return 0;
-}
 #endif
+
+	if (!quiet) {
+		/* Yes, (ex)FAT can contain both of these(as per SDXC specs) */
+		if (pttype)
+			exfat_info("Detected partition table type: %s\n", pttype);
+		if (fstype)
+			exfat_info("Detected filesystem type: %s\n", fstype);
+	}
+
+	if (pttype || fstype) {
+		if (exfat_isatty_stdio() && !ui->force) {
+			exfat_err("Device has existing signatures. Refusing to overwrite; use -F to force.\n");
+			ret = -1;
+		}
+	} else
+		exfat_debug("No existing filesystem detected\n");
+
+#if defined(HAVE_BLKID)
+	blkid_free_probe(probe);
+#else
+	blkid_put_cache(cache);
+#endif
+	return ret;
+alloc_err:
+	exfat_err("Failed to create blkid probe for %s\n", ui->dev_name);
+	return -1;
+}
 
 static void exfat_discard_dev(struct exfat_blk_dev *bd,
 		struct exfat_user_input *ui)
@@ -1527,7 +1556,17 @@ int main(int argc, char *argv[])
 		show_version();
 		exit(EXIT_FAILURE);
 	} else if (!quiet) {
+		const char *blkid_ver = "", *blkid_date = "";
+#ifdef HAVE_BLKID
+		const char *blkid_type = "";
+#else
+		const char *blkid_type = "(libext2?)";
+#endif
+
+		blkid_get_library_version(&blkid_ver, &blkid_date);
+
 		show_version();
+		printf("libblkid%s version : %s (%s)\n", blkid_type, blkid_ver, blkid_date);
 	}
 
 	if (argc - optind != 1) {
@@ -1553,7 +1592,7 @@ int main(int argc, char *argv[])
 	if (ret < 0)
 		goto out;
 
-	ret = check_existing_filesystem(ui.dev_name, ui.force);
+	ret = check_existing_filesystem(&ui, quiet);
 	if (ret < 0)
 		goto out;
 

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -46,6 +46,19 @@ static unsigned int get_new_serial(void)
 	return (unsigned int)(ts.tv_nsec << 12 | ts.tv_sec);
 }
 
+static void show_libblkid_version(void)
+{
+	const char *blkid_ver = "", *blkid_date = "";
+#ifdef HAVE_BLKID
+	const char *blkid_type = "";
+#else
+	const char *blkid_type = "(libext2?)";
+#endif
+
+	blkid_get_library_version(&blkid_ver, &blkid_date);
+	printf("libblkid%s version : %s (%s)\n", blkid_type, blkid_ver, blkid_date);
+}
+
 static inline unsigned long long gpt_backup_array_byte_offset(const struct exfat_blk_dev *bd,
 		const unsigned long long arr_size)
 {
@@ -1554,19 +1567,11 @@ int main(int argc, char *argv[])
 
 	if (version_only) {
 		show_version();
+		show_libblkid_version();
 		exit(EXIT_FAILURE);
 	} else if (!quiet) {
-		const char *blkid_ver = "", *blkid_date = "";
-#ifdef HAVE_BLKID
-		const char *blkid_type = "";
-#else
-		const char *blkid_type = "(libext2?)";
-#endif
-
-		blkid_get_library_version(&blkid_ver, &blkid_date);
-
 		show_version();
-		printf("libblkid%s version : %s (%s)\n", blkid_type, blkid_ver, blkid_date);
+		show_libblkid_version();
 	}
 
 	if (argc - optind != 1) {


### PR DESCRIPTION
Fixes: #354

```
David Timber (2):
  mkfs: improve foreign filesystem detection
  Github actions: add foreign filesystem detection test

 .github/workflows/c-cpp.yml                |  76 +++++++++++++-
 .github/workflows/container-buildtests.yml |  11 +-
 configure.ac                               |  18 ++--
 include/libexfat.h                         |  14 +++
 lib/libexfat.c                             |  14 +++
 manpages/mkfs.exfat.8                      |   9 +-
 mkfs/Android.bp                            |   2 +
 mkfs/mkfs.c                                | 111 ++++++++++++++-------
 8 files changed, 194 insertions(+), 61 deletions(-)

-- 
2.54.0
```