### PR TITLE
dosattr: install to /bin not /sbin

### DIFF
--- a/dosattr/Makefile.am
+++ b/dosattr/Makefile.am
@@ -3,7 +3,7 @@ AM_CFLAGS = -Wall -Wextra -include $(top_builddir)/config.h -I$(top_srcdir)/incl
 lsdosattr_LDADD = $(top_builddir)/lib/libexfat.a
 chdosattr_LDADD = $(top_builddir)/lib/libexfat.a
 
-sbin_PROGRAMS = lsdosattr chdosattr
+bin_PROGRAMS = lsdosattr chdosattr
 
 noinst_HEADERS = dosattr.h
 


### PR DESCRIPTION
lsdosattr and chdosattr were intended to be a user program. An error in automake recipe installed the executables in /sbin.