### PR TITLE
Github Workflows change and optimisation

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -3,12 +3,20 @@ name: C/C++ CI
 on:
   push:
     branches:
-    - master
-    - exfat-next
+      - master
+      - exfat-next
+    paths-ignore:
+      - 'manpages/**'
+      - '**.md'
+      - '**.txt'
+      - '.editorconfig'
+      - '.gitignore'
+      - 'COPYING'
+      - 'NEWS'
   pull_request:
     branches:
-    - master
-    - exfat-next
+      - master
+      - exfat-next
 
 env:
   TEST_PART_TYPES: mbr gpt

--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -24,6 +24,8 @@ jobs:
             util-linux-dev
       - name: Autoconf and Configure
         run: ./autogen.sh && ./configure
+      - name: Distcheck
+        run: make -j "$(nproc)" distcheck
       - name: Build
         run: make -j$((`nproc`+1))
       - name: Install
@@ -47,6 +49,8 @@ jobs:
         run: |
           export LDFLAGS="-fuse-ld=lld"
           ./autogen.sh && ./configure
+      - name: Distcheck
+        run: make -j "$(nproc)" distcheck
       - name: Build
         run:  make -j$((`nproc`+1))
       - name: Install

--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -5,6 +5,14 @@ on:
     branches:
       - master
       - exfat-next
+    paths-ignore:
+      - 'manpages/**'
+      - '**.md'
+      - '**.txt'
+      - '.editorconfig'
+      - '.gitignore'
+      - 'COPYING'
+      - 'NEWS'
   pull_request:
     branches:
       - master

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ autom4te.cache
 /label/exfatlabel
 /mkfs/mkfs.exfat
 /tune/tune.exfat
-/upcase/*.bin
+/dosattr/lsdosattr
+/dosattr/chdosattr

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -33,22 +33,6 @@
 #define dump_dentry_field_wrap(fmt, ...)	\
 	exfat_info("   %-30s  " fmt "\n", "", ##__VA_ARGS__)
 
-static const unsigned char used_bit[] = {
-	0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3,/*  0 ~  19*/
-	2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 1, 2, 2, 3, 2, 3, 3, 4,/* 20 ~  39*/
-	2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5,/* 40 ~  59*/
-	4, 5, 5, 6, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,/* 60 ~  79*/
-	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 2, 3, 3, 4,/* 80 ~  99*/
-	3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6,/*100 ~ 119*/
-	4, 5, 5, 6, 5, 6, 6, 7, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4,/*120 ~ 139*/
-	3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,/*140 ~ 159*/
-	2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5,/*160 ~ 179*/
-	4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7, 2, 3, 3, 4, 3, 4, 4, 5,/*180 ~ 199*/
-	3, 4, 4, 5, 4, 5, 5, 6, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6,/*200 ~ 219*/
-	5, 6, 6, 7, 3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7,/*220 ~ 239*/
-	4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8             /*240 ~ 255*/
-};
-
 static void usage(void)
 {
 	fprintf(stderr, "Usage: dump.exfat\n");
@@ -74,18 +58,6 @@ static struct option opts[] = {
 	{"?",			no_argument,		NULL,	'?' },
 	{NULL,			0,			NULL,	 0  }
 };
-
-static unsigned int exfat_count_used_clusters(unsigned char *bitmap,
-		unsigned long long bitmap_len)
-{
-	unsigned int count = 0;
-	unsigned long long i;
-
-	for (i = 0; i < bitmap_len; i++)
-		count += used_bit[bitmap[i]];
-
-	return count;
-}
 
 static int exfat_read_dentry(struct exfat *exfat, struct exfat_inode *inode,
 		uint8_t type, struct exfat_dentry *dentry, off_t *dentry_off)
@@ -226,9 +198,7 @@ static int exfat_show_fs_info(struct exfat *exfat)
 			return -EIO;
 		}
 
-		used_clus = exfat_count_used_clusters(
-				(unsigned char *)exfat->disk_bitmap,
-				bitmap_len);
+		used_clus = exfat_count_used_clusters(exfat->disk_bitmap, (size_t)bitmap_len);
 
 		exfat_info("\n---------------- Show the statistics ----------------\n");
 		dump_field("Cluster size", "%u", bd->cluster_size);

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1766,18 +1766,6 @@ static void exfat_show_info(struct exfat_fsck *fsck, const char *dev_name)
 			exfat_stat.fixed_count);
 }
 
-static clus_t count_bitmap_set_bits(struct exfat *exfat)
-{
-	clus_t count = 0;
-	size_t i, bytes = exfat->disk_bitmap_size;
-
-	for (i = 0; i + sizeof(uint32_t) <= bytes; i += sizeof(uint32_t))
-		count += __builtin_popcount(*(uint32_t *)(exfat->disk_bitmap + i));
-	for (; i < bytes; i++)
-		count += __builtin_popcount(exfat->disk_bitmap[i]);
-	return count;
-}
-
 static int do_put_mbr(const struct exfat_blk_dev *bd, struct pbr *bs, const bool recursive)
 {
 	int ret = 0;
@@ -2078,7 +2066,8 @@ int main(int argc, char * const argv[])
 	}
 
 	if (exfat_fsck.options & FSCK_OPTS_PROGRESS_BAR) {
-		used_clus_count = count_bitmap_set_bits(exfat_fsck.exfat);
+		used_clus_count = exfat_count_used_clusters(exfat_fsck.exfat->disk_bitmap,
+				(size_t)exfat_fsck.exfat->disk_bitmap_size);
 		progress_init(&exfat_fsck.progress_bar, 0, used_clus_count, 0);
 	}
 

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -211,6 +211,10 @@ int exfat_bitmap_find_zero(struct exfat *exfat, unsigned char *bmap,
 			   clus_t start_clu, clus_t *next);
 int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 			  clus_t start_clu, clus_t *next);
+/*
+ * Count ones in the bitmap. The function won't handle unaligned bitmaps.
+ */
+unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len);
 
 void show_version(void);
 

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -115,6 +115,22 @@ int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 				     start_clu, next, 1);
 }
 
+unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len)
+{
+	const size_t lc = bitmap_len / sizeof(unsigned long);
+	unsigned int ret = 0;
+
+	assert((uintptr_t)bitmap % sizeof(unsigned long) == 0);
+
+	for (size_t i = 0; i < lc; i++)
+		ret += __builtin_popcountl(((unsigned long*)bitmap)[i]);
+	for (size_t i = lc * sizeof(unsigned long); i < bitmap_len; i++)
+		ret += __builtin_popcountl(((unsigned char*)bitmap)[i]);
+
+	return ret;
+}
+
+
 wchar_t exfat_bad_char(wchar_t w)
 {
 	return (w < 0x0020)


### PR DESCRIPTION
Just minor touches here and there.

```
David Timber (4):
  libexfat: use __builtin_popcountl() across the project
  gitignore: add missing patterns for dosattr
  Github workflow: add tarball distcheck
  Github Workflows: add paths-ignore

 .github/workflows/c-cpp.yml                | 16 ++++++++---
 .github/workflows/container-buildtests.yml | 12 ++++++++
 .gitignore                                 |  3 +-
 dump/dump.c                                | 32 +---------------------
 fsck/fsck.c                                | 15 ++--------
 include/libexfat.h                         |  4 +++
 lib/libexfat.c                             | 16 +++++++++++
 7 files changed, 49 insertions(+), 49 deletions(-)

-- 
2.54.0
```