### PR TITLE
CI improvements, add make distcheck and avoid execution on non-code changes

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,14 +1,27 @@
 name: C/C++ CI
 
+# Try to avoid running this rather big matrix build workflow
+# on non-code changes. The smaller build tests in container-buildtests.yml
+# include a make distcheck and run for almost all changes.
 on:
   push:
     branches:
-    - master
-    - exfat-next
+      - master
+      - exfat-next
+    paths-ignore:
+      - 'manpages/**'
+      - '**.md'
+      - '**.txt'
+      - 'NEWS'
   pull_request:
     branches:
-    - master
-    - exfat-next
+      - master
+      - exfat-next
+    paths-ignore:
+      - 'manpages/**'
+      - '**.md'
+      - '**.txt'
+      - 'NEWS'
 
 env:
   TEST_PART_TYPES: mbr gpt

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -66,9 +66,8 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get --update --quiet --yes install \
-             linux-headers-$(uname -r) xz-utils \
-             valgrind libblkid-dev ${{ matrix.cc }}
-        sudo apt-get install -y linux-modules-extra-$(uname -r)
+             linux-headers-$(uname -r) linux-modules-extra-$(uname -r) \
+             xz-utils valgrind libblkid-dev ${{ matrix.cc }}
     - name: Build
       run: |
         export "CC=${{ matrix.cc }}"
@@ -180,11 +179,10 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get --update --quiet --yes install \
-             linux-headers-$(uname -r) xz-utils curl \
-             cryptsetup parted dosfstools e2fsprogs btrfs-progs f2fs-tools ntfs-3g xfsprogs \
-             ${{ matrix.gcc }} ${{ matrix.qemu }} \
+             linux-headers-$(uname -r) linux-modules-extra-$(uname -r) xz-utils curl \
+             cryptsetup parted dosfstools e2fsprogs btrfs-progs f2fs-tools ntfs-3g \
+             xfsprogs ${{ matrix.gcc }} ${{ matrix.qemu }} \
              qemu-user qemu-utils
-        sudo apt-get install -y linux-modules-extra-$(uname -r)
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
         export PATH=/usr/local/lib:$PATH
     - name: Build libblkid

--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -24,6 +24,8 @@ jobs:
             util-linux-dev
       - name: Autoconf and Configure
         run: ./autogen.sh && ./configure
+      - name: Distcheck
+        run: make distcheck
       - name: Build
         run: make -j$((`nproc`+1))
       - name: Install
@@ -47,6 +49,8 @@ jobs:
         run: |
           export LDFLAGS="-fuse-ld=lld"
           ./autogen.sh && ./configure
+      - name: Distcheck
+        run: make distcheck
       - name: Build
         run:  make -j$((`nproc`+1))
       - name: Install

--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -1,14 +1,24 @@
 name: Container Buildtests
 
+# This workflow includes a make distcheck,
+# thus we execute it also on most non-code changes
+# to catch e.g. files missing in the generated
+# make dist tarball.
 on:
   push:
     branches:
       - master
       - exfat-next
+    paths-ignore:
+      - '**.md'
+      - 'NEWS'
   pull_request:
     branches:
       - master
       - exfat-next
+    paths-ignore:
+      - '**.md'
+      - 'NEWS'
 
 jobs:
   container-build-alpine:


### PR DESCRIPTION
* Run `make distcheck` as part of the container based workflows.
* Avoid workflow execution on non-code changes.
* Install all packages with one `apt-get install` invocation.