### PR TITLE
configure.ac: Fix build of dosattr programs when shell != bash

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_CONFIG_FILES([
 ])
 
 AC_CHECK_HEADERS([fts.h], [have_fts_h="yes"])
-AM_CONDITIONAL([ENABLE_DOSATTR], [test "x$have_fts_h" == "xyes"])
+AM_CONDITIONAL([ENABLE_DOSATTR], [test "x$have_fts_h" = "xyes"])
 AM_COND_IF(
 	[ENABLE_DOSATTR],
 	[AC_CHECK_LIB([fts], [fts_open])],


### PR DESCRIPTION
Otherwise build of these fails beacuse configure doesn't find fts.h:

 checking for fts.h... yes
 ./configure: 13225: test: xyes: unexpected operator
 <fts.h> not found. Not building dosattr programs