### PR TITLE
configure.ac: use '=', not '=='

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_CONFIG_FILES([
 ])
 
 AC_CHECK_HEADERS([fts.h], [have_fts_h="yes"])
-AM_CONDITIONAL([ENABLE_DOSATTR], [test "x$have_fts_h" == "xyes"])
+AM_CONDITIONAL([ENABLE_DOSATTR], [test "x$have_fts_h" = "xyes"])
 AM_COND_IF(
 	[ENABLE_DOSATTR],
 	[AC_CHECK_LIB([fts], [fts_open])],


### PR DESCRIPTION
'==' isn't guaranteed to work in POSIX shells.