### PR TITLE
Minor bug fixes and improvements (July 2026)

### DIFF
--- a/defrag/defrag.c
+++ b/defrag/defrag.c
@@ -972,8 +972,7 @@ int main(int argc, char *argv[])
 
 	/* step-0: Parameter Processing and Mode Recognition */
 
-	if (!setlocale(LC_CTYPE, ""))
-		exfat_err("failed to init locale/codeset\n");
+	setlocale(LC_ALL, "");
 
 	/*
 	 * Recognizable command format:

--- a/dosattr/chdosattr.c
+++ b/dosattr/chdosattr.c
@@ -241,8 +241,7 @@ int main(int argc, char *argv[])
 	static int c;
 	static int retval;
 
-	setlocale(LC_MESSAGES, "");
-	setlocale(LC_CTYPE, "");
+	setlocale(LC_ALL, "");
 
 	if (argc <= 1)
 		usage();

--- a/dosattr/lsdosattr.c
+++ b/dosattr/lsdosattr.c
@@ -210,8 +210,7 @@ int main(int argc, char *argv[])
 #define MY_FTSOPTS (FTS_PHYSICAL | FTS_SEEDOT)
 	static int c, retval;
 
-	setlocale(LC_MESSAGES, "");
-	setlocale(LC_CTYPE, "");
+	setlocale(LC_ALL, "");
 
 	if (!(argc && *argv))
 		usage();

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -198,7 +198,8 @@ static int exfat_show_fs_info(struct exfat *exfat)
 			return -EIO;
 		}
 
-		used_clus = exfat_count_used_clusters(exfat->disk_bitmap, (size_t)bitmap_len);
+		used_clus = exfat_count_used_clusters(exfat->disk_bitmap, (size_t)bitmap_len,
+						      exfat->clus_count);
 
 		exfat_info("\n---------------- Show the statistics ----------------\n");
 		dump_field("Cluster size", "%u", bd->cluster_size);

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -900,8 +900,7 @@ int main(int argc, char *argv[])
 	exfat_init_user_input(&ui);
 	ui.writeable = false;
 
-	if (!setlocale(LC_CTYPE, ""))
-		exfat_err("failed to init locale/codeset\n");
+	setlocale(LC_ALL, "");
 
 	opterr = 0;
 	while ((c = getopt_long(argc, argv, "iVhd:s:rc", opts, NULL)) != EOF)

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -1921,8 +1921,7 @@ int main(int argc, char * const argv[])
 
 	print_level = EXFAT_ERROR;
 
-	if (!setlocale(LC_CTYPE, ""))
-		exfat_err("failed to init locale/codeset\n");
+	setlocale(LC_ALL, "");
 
 	opterr = 0;
 	while ((c = getopt_long(argc, argv, "arynpbsPVvh", opts, NULL)) != EOF) {

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -2066,7 +2066,8 @@ int main(int argc, char * const argv[])
 
 	if (exfat_fsck.options & FSCK_OPTS_PROGRESS_BAR) {
 		used_clus_count = exfat_count_used_clusters(exfat_fsck.exfat->disk_bitmap,
-				(size_t)exfat_fsck.exfat->disk_bitmap_size);
+				(size_t)exfat_fsck.exfat->disk_bitmap_size,
+				exfat_fsck.exfat->clus_count);
 		progress_init(&exfat_fsck.progress_bar, 0, used_clus_count, 0);
 	}
 

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -513,8 +513,8 @@ static int exfat_boot_region_check(struct exfat_blk_dev *blkdev,
 				   bool ignore_bad_fs_name)
 {
 	struct pbr *boot_sect;
-	unsigned int sect_size;
-	int ret;
+	unsigned int sect_size = 0; /* zero if invalid */
+	int ret = -EINVAL;
 
 	/* First, find out the exfat sector size */
 	boot_sect = malloc(sizeof(*boot_sect));
@@ -534,12 +534,14 @@ static int exfat_boot_region_check(struct exfat_blk_dev *blkdev,
 		return -ENOTSUP;
 	}
 
-	sect_size = 1 << boot_sect->bsx.sect_size_bits;
+	/* check boot regions */
+	if (9 <= boot_sect->bsx.sect_size_bits && boot_sect->bsx.sect_size_bits <= 12) {
+		sect_size = 1 << boot_sect->bsx.sect_size_bits;
+		ret = read_boot_region(blkdev, bs, BOOT_SEC_IDX, sect_size, true);
+	} else
+		exfat_err("invalid sector size\n");
 	free(boot_sect);
 
-	/* check boot regions */
-	ret = read_boot_region(blkdev, bs,
-			       BOOT_SEC_IDX, sect_size, true);
 	if (ret == -EINVAL &&
 	    exfat_repair_ask(&exfat_fsck, ER_BS_BOOT_REGION,
 			     "boot region is corrupted. try to restore the region from backup"
@@ -547,7 +549,7 @@ static int exfat_boot_region_check(struct exfat_blk_dev *blkdev,
 		const unsigned int sector_sizes[] = {512, 4096, 1024, 2048};
 		unsigned int i;
 
-		if (sect_size >= 512 && sect_size <= EXFAT_MAX_SECTOR_SIZE) {
+		if (sect_size) {
 			ret = read_boot_region(blkdev, bs,
 					       BACKUP_BOOT_SEC_IDX, sect_size,
 					       false);

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -424,8 +424,8 @@ extern unsigned int print_level;
 #define exfat_print_guid(f, msg, guid)					\
 		f("%s: %02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x\n",\
 			(msg),						\
-			(guid)[0], (guid)[1], (guid)[2], (guid)[3],	\
-			(guid)[4], (guid)[5], (guid)[6], (guid)[7],	\
+			(guid)[3], (guid)[2], (guid)[1], (guid)[0],	\
+			(guid)[5], (guid)[4], (guid)[7], (guid)[6],	\
 			(guid)[8], (guid)[9], (guid)[10], (guid)[11],	\
 			(guid)[12], (guid)[13], (guid)[14], (guid)[15])
 

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -211,7 +211,8 @@ int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 /*
  * Count ones in the bitmap. The function won't handle unaligned bitmaps.
  */
-unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len);
+unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len,
+		const unsigned int clamp);
 
 void show_version(void);
 

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -125,22 +125,14 @@ extern const char *dummy_bootcode_msg;
 
 struct exfat_user_input {
 	const char *dev_name;
-	bool writeable;
+	const char *guid;
+	unsigned char *fat_table_buff;
 	unsigned int sector_size;
 	unsigned int cluster_size;
 	unsigned int sec_per_clu;
 	unsigned int boundary_align;
-	bool pack_bitmap;
-	bool quick;
-	bool force;
-	bool verify;
-	bool discard;
-	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
-	int volume_label_len;
 	unsigned int volume_serial;
-	const char *guid;
-	unsigned char *fat_table_buff;
-
+	int volume_label_len;
 	struct {
 		const char *file;
 		const unsigned char *table;
@@ -148,10 +140,15 @@ struct exfat_user_input {
 		size_t len;
 		void (*free)(struct exfat_user_input *ui);
 	} upcase;
-
 	const char *bootcode_msg;
-
 	enum exfat_part_table_type part_table;
+	__u16 volume_label[VOLUME_LABEL_MAX_LEN];
+	bool writeable:1;
+	bool pack_bitmap:1;
+	bool quick:1;
+	bool force:1;
+	bool verify:1;
+	bool discard:1;
 };
 
 /* Returns true if the option used or the option argument is not an empty string */

--- a/label/label.c
+++ b/label/label.c
@@ -47,8 +47,7 @@ int main(int argc, char *argv[])
 	exfat_init_blk_dev_info(&bd);
 	exfat_init_user_input(&ui);
 
-	if (!setlocale(LC_CTYPE, ""))
-		exfat_err("failed to init locale/codeset\n");
+	setlocale(LC_ALL, "");
 
 	if (argc == 2)
 		flags = EXFAT_GET_VOLUME_LABEL;

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -115,7 +115,8 @@ int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 				     start_clu, next, 1);
 }
 
-unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len)
+unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len,
+		const unsigned int clamp)
 {
 	const size_t lc = bitmap_len / sizeof(unsigned long);
 	unsigned int ret = 0;
@@ -127,7 +128,7 @@ unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_l
 	for (size_t i = lc * sizeof(unsigned long); i < bitmap_len; i++)
 		ret += __builtin_popcountl(((unsigned char*)bitmap)[i]);
 
-	return ret;
+	return MIN(ret, clamp);
 }
 
 

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -979,6 +979,7 @@ out:
 
 static int set_guid(__u8 *guid, const char *input)
 {
+	__u8 buf[EXFAT_GUID_LEN];
 	int i, j, zero_len = 0;
 	int len = strlen(input);
 
@@ -1005,9 +1006,9 @@ static int set_guid(__u8 *guid, const char *input)
 		}
 
 		if (j & 1)
-			guid[j >> 1] |= ch;
+			buf[j >> 1] |= ch;
 		else
-			guid[j >> 1] = ch << 4;
+			buf[j >> 1] = ch << 4;
 
 		j++;
 
@@ -1019,6 +1020,27 @@ static int set_guid(__u8 *guid, const char *input)
 		exfat_err("%s is invalid for volume GUID\n", input);
 		return -EINVAL;
 	}
+
+	guid[0] = buf[3];
+	guid[1] = buf[2];
+	guid[2] = buf[1];
+	guid[3] = buf[0];
+
+	guid[4] = buf[5];
+	guid[5] = buf[4];
+
+	guid[6] = buf[7];
+	guid[7] = buf[6];
+
+	guid[8] = buf[8];
+	guid[9] = buf[9];
+
+	guid[10] = buf[10];
+	guid[11] = buf[11];
+	guid[12] = buf[12];
+	guid[13] = buf[13];
+	guid[14] = buf[14];
+	guid[15] = buf[15];
 
 	return 0;
 }

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -1694,8 +1694,14 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	exfat_info("Synchronizing...\n");
+	if (!quiet)
+		exfat_info("Synchronizing...\n");
 	ret = fsync(bd.dev_fd);
+	if (ret) {
+		exfat_err("Sync failed: %s\n", strerror(errno));
+		goto out;
+	}
+
 out:
 	if (ret && gptwo_tried) {
 		exfat_info("Wiping out GPT structures...\n");
@@ -1717,8 +1723,10 @@ out:
 	exfat_deinit_blk_dev_info(&bd);
 	exfat_deinit_user_input(&ui);
 
-	if (!ret)
-		exfat_info("\nexFAT format complete!\n");
+	if (!ret) {
+		if (!quiet)
+			exfat_info("\nexFAT format complete!\n");
+	}
 	else
 		exfat_err("\nexFAT format fail!\n");
 	return ret ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -1446,8 +1446,7 @@ int main(int argc, char *argv[])
 	exfat_init_blk_dev_info(&bd);
 	exfat_init_user_input(&ui);
 
-	if (!setlocale(LC_CTYPE, ""))
-		exfat_err("failed to init locale/codeset\n");
+	setlocale(LC_ALL, "");
 
 	opterr = 0;
 	while ((c = getopt_long(argc, argv, "n:L:U:s:c:b:P:fFCKVqvh", opts, NULL)) != EOF)

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -1811,8 +1811,8 @@ void exfat_gen_guid(void *out)
 			uint32_t a;
 			uint16_t b;
 			uint8_t ver[2];
-			uint16_t c;
-			uint32_t d;
+			uint8_t var[2];
+			uint32_t c;
 		} parts;
 	} __attribute__((__packed__)) rnd = { 0, };
 	struct timespec ts[2] = { 0, };
@@ -1842,8 +1842,9 @@ void exfat_gen_guid(void *out)
 		if (memcmp(&rnd, zm, 16) == 0)
 			continue;
 
-		rnd.parts.ver[0] &= 0xF0;
-		rnd.parts.ver[0] |= 0x04;
+		rnd.parts.ver[1] &= 0x0F;
+		rnd.parts.ver[1] |= 0x40;
+		rnd.parts.var[0] = (rnd.parts.var[0] & 0x3F) | 0x80;
 		memcpy(out, &rnd, 16);
 		return;
 	}

--- a/mkfs/mkfs.c
+++ b/mkfs/mkfs.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#include <linux/fs.h>
 #include <fcntl.h>
 #include <getopt.h>
 #include <inttypes.h>
@@ -1700,6 +1701,16 @@ int main(int argc, char *argv[])
 	if (ret) {
 		exfat_err("Sync failed: %s\n", strerror(errno));
 		goto out;
+	}
+
+	if (ui.part_table && bd.isblk) {
+		errno = 0;
+		if (ioctl(bd.dev_fd, BLKRRPART) != 0) {
+			exfat_err("BLKRRPART ioctl(): %s\n", strerror(errno));
+			exfat_err("Failed to inform the kernel of the new partition table.\n"
+				  "The volume may not show up and you'll have to reconnect "
+				  "the device or reboot to be able to use the volume.\n");
+		}
 	}
 
 out:

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -60,8 +60,7 @@ int main(int argc, char *argv[])
 	exfat_init_blk_dev_info(&bd);
 	exfat_init_user_input(&ui);
 
-	if (!setlocale(LC_CTYPE, ""))
-		exfat_err("failed to init locale/codeset\n");
+	setlocale(LC_ALL, "");
 
 	opterr = 0;
 	while ((c = getopt_long(argc, argv, "I:iL:lU:uVvh", opts, NULL)) != EOF)


### PR DESCRIPTION
- Closes: https://github.com/exfatprogs/exfatprogs/issues/374
- Closes: https://github.com/exfatprogs/exfatprogs/issues/375
- Closes: https://github.com/exfatprogs/exfatprogs/issues/352

I don't care what `checkpatch.pl` script says. This notation is easy to read:

```c
9 <= boot_sect->bsx.sect_size_bits && boot_sect->bsx.sect_size_bits <= 12
```

Cheers!

```
David Timber (8):
  treewide: use setlocale(LC_ALL, "")
  libexfat.h: rearrange members of struct exfat_user_input
  libexfat: ignore trailing garbage in exfat_count_used_clusters()
  libexfat: fix endianness of GUID representation
  fsck: fix crash due to invalid sector size
  mkfs: fix final fsync and success/failure reports
  mkfs: tell kernel to scan for partitions
  mkfs: fix GUID generation

 defrag/defrag.c     |  3 +--
 dosattr/chdosattr.c |  3 +--
 dosattr/lsdosattr.c |  3 +--
 dump/dump.c         |  6 +++---
 fsck/fsck.c         | 22 ++++++++++++----------
 include/libexfat.h  | 30 ++++++++++++++----------------
 label/label.c       |  3 +--
 lib/libexfat.c      | 31 +++++++++++++++++++++++++++----
 mkfs/mkfs.c         | 37 ++++++++++++++++++++++++++++---------
 tune/tune.c         |  3 +--
 10 files changed, 89 insertions(+), 52 deletions(-)

-- 
2.55.0
```