### PR TITLE
exfatprogs on a potato: mmap() allocation bitmap handling support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -17,6 +17,7 @@ on:
     branches:
       - master
       - exfat-next
+  workflow_dispatch:
 
 env:
   TEST_PART_TYPES: mbr gpt

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -75,6 +75,7 @@ jobs:
         pushd tests
         export FSCK1="valgrind --error-exitcode=1 ../fsck/fsck.exfat"
         export FSCK2="valgrind --error-exitcode=1 ../fsck/fsck.exfat"
+        export FSCK_OPTS_EXTRA="-vv"
         sudo -E ./test_fsck.sh
         popd
     - name: Run the rest with Valgrind
@@ -257,6 +258,7 @@ jobs:
     - name: run fsck repair testcases
       run: |
         pushd tests
+        export FSCK_OPTS_EXTRA="-vv"
         export FSCK1="${{ matrix.run }} ../fsck/fsck.exfat"
         export FSCK2="fsck.exfat"
         sudo -E ./test_fsck.sh

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -18,6 +18,14 @@ on:
       - master
       - exfat-next
   workflow_dispatch:
+    inputs:
+      EXFAT_MMAP:
+        type: string
+        required: false
+      EXFAT_SCRATCH_AMAP:
+        type: string
+        required: false
+        default: /var/tmp
 
 env:
   TEST_PART_TYPES: mbr gpt
@@ -57,6 +65,9 @@ jobs:
       fail-fast: false
       matrix:
         cc: [clang, gcc]
+    env:
+      EXFAT_MMAP: ${{ inputs.EXFAT_MMAP }}
+      EXFAT_SCRATCH_AMAP: ${{ inputs.EXFAT_SCRATCH_AMAP }}
     steps:
     - uses: actions/checkout@v6
     - name: Install packages
@@ -173,6 +184,9 @@ jobs:
             gcc:  gcc-i686-linux-gnu
             run:  qemu-i386
             name: i686
+    env:
+      EXFAT_MMAP: ${{ inputs.EXFAT_MMAP }}
+      EXFAT_SCRATCH_AMAP: ${{ inputs.EXFAT_SCRATCH_AMAP }}
     steps:
     - name: Install packages
       run: |

--- a/.github/workflows/container-buildtests.yml
+++ b/.github/workflows/container-buildtests.yml
@@ -17,6 +17,7 @@ on:
     branches:
       - master
       - exfat-next
+  workflow_dispatch:
 
 jobs:
   container-build-alpine:

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ SUBDIRS = lib mkfs fsck tune label dump exfat2img upcase dosattr
 
 # manpages
 dist_man1_MANS =
+dist_man7_MANS = manpages/exfatprogs-env.7
 dist_man8_MANS =		\
 	manpages/fsck.exfat.8	\
 	manpages/tune.exfat.8	\

--- a/defrag/defrag.c
+++ b/defrag/defrag.c
@@ -110,20 +110,17 @@ static int exfat_rw_bitmap(struct exfat *exfat, bool read)
 
 	/* Record bitmap cluster and size */
 	exfat->disk_bitmap_clus = le32_to_cpu(dentry->bitmap_start_clu);
-	exfat->disk_bitmap_size = DIV_ROUND_UP(exfat->clus_count, 8);
 
 	free(filter.out.dentry_set);
 
 	/* Perform read or write operation */
 	if (read) {
-		rw = exfat_read_full(exfat->blk_dev->dev_fd, exfat->alloc_bitmap,
-					exfat->disk_bitmap_size,
+		rw = exfat_read_full(exfat->blk_dev->dev_fd, exfat->alloc_bitmap, exfat->bm_len,
 					exfat_c2o(exfat, exfat->disk_bitmap_clus));
 		if (!rw)
 			return -EIO;
 	} else {
-		rw = exfat_write_full(exfat->blk_dev->dev_fd, exfat->alloc_bitmap,
-					exfat->disk_bitmap_size,
+		rw = exfat_write_full(exfat->blk_dev->dev_fd, exfat->alloc_bitmap, exfat->bm_len,
 					exfat_c2o(exfat, exfat->disk_bitmap_clus));
 		if (!rw)
 			return -EIO;
@@ -1038,7 +1035,7 @@ int main(int argc, char *argv[])
 
 	/* Step 2: Initialize exfat structure */
 	memset(&defrag, 0, sizeof(defrag));
-	defrag.exfat = exfat_alloc_exfat(&bd, NULL, NULL);
+	defrag.exfat = exfat_alloc_exfat(&bd, NULL, NULL, true);
 	if (defrag.exfat == NULL) {
 		exfat_err("fail in exfat_alloc_exfat\n");
 		ret = 1;

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -188,12 +188,7 @@ static int exfat_show_fs_info(struct exfat *exfat)
 		dump_field("Bitmap start cluster", "%x", bitmap_clu);
 		dump_field("Bitmap size", "%llu", bitmap_len);
 
-		/*
-		 * FIXME shouldn't it be `bitmap_len < exfat->bm_len` ???
-		 * The spec says nothing about this. fsck expects the exact size
-		 * (DIV_ROUND_UP(exfat->clus_count, 8)).
-		 */
-		if (bitmap_len > exfat->bm_size) {
+		if (bitmap_len != exfat->bm_len) {
 			exfat_err("Invalid bitmap size: %llu\n", bitmap_len);
 			return -EINVAL;
 		}

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <locale.h>
 #include <inttypes.h>
+#include <assert.h>
 
 #include "exfat_ondisk.h"
 #include "libexfat.h"
@@ -187,18 +188,24 @@ static int exfat_show_fs_info(struct exfat *exfat)
 		dump_field("Bitmap start cluster", "%x", bitmap_clu);
 		dump_field("Bitmap size", "%llu", bitmap_len);
 
-		if (bitmap_len > EXFAT_BITMAP_SIZE(exfat->clus_count)) {
+		/*
+		 * FIXME shouldn't it be `bitmap_len < exfat->bm_len` ???
+		 * The spec says nothing about this. fsck expects the exact size
+		 * (DIV_ROUND_UP(exfat->clus_count, 8)).
+		 */
+		if (bitmap_len > exfat->bm_size) {
 			exfat_err("Invalid bitmap size: %llu\n", bitmap_len);
 			return -EINVAL;
 		}
 
-		if (!exfat_read_full(bd->dev_fd, exfat->disk_bitmap, bitmap_len,
-				exfat_c2o(exfat, bitmap_clu))) {
-			exfat_err("bitmap read failed: %d\n", errno);
-			return -EIO;
+		if (!exfat_load_disk_bitmap(exfat, exfat_c2o(exfat, bitmap_clu), false)) {
+			const int saved_errno = errno;
+
+			exfat_err("bitmap read failed: %s\n", strerror(errno));
+			return -saved_errno;
 		}
 
-		used_clus = exfat_count_used_clusters(exfat->disk_bitmap, (size_t)bitmap_len,
+		used_clus = exfat_count_used_clusters(exfat->disk_bitmap, exfat->bm_len,
 						      exfat->clus_count);
 
 		exfat_info("\n---------------- Show the statistics ----------------\n");
@@ -427,6 +434,8 @@ static void exfat_show_cluster_chain(struct exfat *exfat,
 	clus_t clu, next_clu;
 	clus_t count = 0, num_clus;
 	bool first = true;
+
+	assert(exfat->alloc_bitmap != NULL);
 
 	clu = le32_to_cpu(ed->stream_start_clu);
 	num_clus = DIV_ROUND_UP(le64_to_cpu(ed->stream_size), exfat->clus_size);
@@ -875,7 +884,6 @@ static int exfat_show_dentry_set_by_path(struct exfat *exfat, const char *path,
 
 		memset(&ed, 0, sizeof(ed));
 		ed.stream_start_clu = cpu_to_le32(inode->first_clus);
-		memset(exfat->alloc_bitmap, 0, EXFAT_BITMAP_SIZE(exfat->clus_count));
 
 		exfat_show_cluster_chain(exfat, &ed);
 	} else
@@ -941,7 +949,7 @@ int main(int argc, char *argv[])
 	if (ret < 0)
 		goto out;
 
-	exfat = exfat_alloc_exfat(&bd, NULL, NULL);
+	exfat = exfat_alloc_exfat(&bd, NULL, NULL, flags & DUMP_CLUSTER_CHAIN);
 	if (!exfat) {
 		ret = -ENOMEM;
 		goto out;

--- a/exfat2img/exfat2img.c
+++ b/exfat2img/exfat2img.c
@@ -118,7 +118,7 @@ static int create_exfat2img(struct exfat2img *ei, const char *out_path)
 {
 	int err;
 
-	ei->exfat = exfat_alloc_exfat(&ei->bdev, NULL, NULL);
+	ei->exfat = exfat_alloc_exfat(&ei->bdev, NULL, NULL, ei->is_stdout);
 	if (!ei->exfat)
 		return -ENOMEM;
 
@@ -382,13 +382,9 @@ static int read_bitmap(struct exfat2img *ei, struct exfat_de_iter *iter)
 	}
 
 	exfat->disk_bitmap_clus = le32_to_cpu(dentry->bitmap_start_clu);
-	exfat->disk_bitmap_size = DIV_ROUND_UP(exfat->clus_count, 8);
 
-	return dump_clusters(ei,
-			     exfat->disk_bitmap_clus,
-			     exfat->disk_bitmap_clus +
-			     DIV_ROUND_UP(exfat->disk_bitmap_size,
-					  exfat->clus_size));
+	return dump_clusters(ei, exfat->disk_bitmap_clus, exfat->disk_bitmap_clus +
+			     DIV_ROUND_UP(exfat->bm_size, exfat->clus_size));
 }
 
 static int read_upcase_table(struct exfat2img *ei,

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -13,7 +13,6 @@
 #include <errno.h>
 #include <locale.h>
 #include <assert.h>
-#include <fcntl.h>
 
 #include "exfat_ondisk.h"
 #include "libexfat.h"
@@ -995,7 +994,7 @@ static int read_bitmap(struct exfat *exfat)
 		.in.param	= NULL,
 	};
 	struct exfat_dentry *dentry;
-	uint64_t map_size, need_map_size;
+	uint64_t map_size;
 	int retval;
 
 	retval = exfat_lookup_dentry_set(exfat, exfat->root, &filter);
@@ -1009,11 +1008,10 @@ static int read_bitmap(struct exfat *exfat)
 
 	/* Validate on-disk bitmap size and required size */
 	map_size = le64_to_cpu(dentry->bitmap_size);
-	need_map_size = DIV_ROUND_UP(exfat->clus_count, 8);
-	if (map_size != need_map_size &&
+	if (map_size != exfat->bm_len &&
 		exfat_repair_ask(&exfat_fsck, ER_DE_BITMAP,
 				"ERROR: invalid bitmap size. %lld", map_size)) {
-		dentry->bitmap_size = cpu_to_le64(need_map_size);
+		dentry->bitmap_size = cpu_to_le64(exfat->bm_len);
 		if (!exfat_write_full(exfat->blk_dev->dev_fd, dentry, DENTRY_SIZE,
 				      filter.out.dev_offset)) {
 			exfat_err("failed to write bitmap dentry\n");
@@ -1021,8 +1019,7 @@ static int read_bitmap(struct exfat *exfat)
 		}
 	}
 
-	if (le64_to_cpu(dentry->bitmap_size) <
-			DIV_ROUND_UP(exfat->clus_count, 8)) {
+	if (le64_to_cpu(dentry->bitmap_size) < exfat->bm_len) {
 		exfat_err("invalid size of allocation bitmap. 0x%" PRIx64 "\n",
 				le64_to_cpu(dentry->bitmap_size));
 		retval = -EINVAL;
@@ -1036,16 +1033,12 @@ static int read_bitmap(struct exfat *exfat)
 	}
 
 	exfat->disk_bitmap_clus = le32_to_cpu(dentry->bitmap_start_clu);
-	exfat->disk_bitmap_size = DIV_ROUND_UP(exfat->clus_count, 8);
 
-	exfat_bitmap_set_range(exfat, exfat->alloc_bitmap,
-			       le32_to_cpu(dentry->bitmap_start_clu),
-			       DIV_ROUND_UP(exfat->disk_bitmap_size,
-					    exfat->clus_size));
-	if (!exfat_read_full(exfat->blk_dev->dev_fd, exfat->disk_bitmap,
-			exfat->disk_bitmap_size,
-			exfat_c2o(exfat, exfat->disk_bitmap_clus)))
-		retval = -EIO;
+	exfat_bitmap_set_range(exfat, exfat->alloc_bitmap, le32_to_cpu(dentry->bitmap_start_clu),
+			       (unsigned int)DIV_ROUND_UP(exfat->bm_len, exfat->clus_size));
+	if (!exfat_load_disk_bitmap(exfat, exfat_c2o(exfat, exfat->disk_bitmap_clus),
+				    exfat_fsck.options & FSCK_OPTS_REPAIR_WRITE))
+		retval = -errno;
 out:
 	free(filter.out.dentry_set);
 	return retval;
@@ -1459,39 +1452,60 @@ err:
 static int write_bitmap(struct exfat_fsck *fsck)
 {
 	struct exfat *exfat = fsck->exfat;
-	bitmap_t *disk_b, *alloc_b, *ohead_b;
-	off_t dev_offset;
-	unsigned int i, bitmap_bytes, byte_offset, write_bytes;
+	bitmap_t *disk_b = (bitmap_t *)exfat->disk_bitmap;
+	const bitmap_t *alloc_b = (bitmap_t *)exfat->alloc_bitmap;
+	const size_t bm_cnt = exfat->bm_size / sizeof(bitmap_t);
+	size_t bm_step;
+	size_t bm_step_bytes;
+	size_t psz = (size_t)exfat->pagesize;
 
-	dev_offset = exfat_c2o(exfat, exfat->disk_bitmap_clus);
-	bitmap_bytes = EXFAT_BITMAP_SIZE(le32_to_cpu(exfat->bs->bsx.clu_count));
+	/*
+	 * Process one cluster or one page at a time(whichever is larger)
+	 * to make life easier for the kernel and devices with write
+	 * amplification like SMR HDD and NAND flash.
+	 *
+	 * NOTE: if the page size is not power of two, this whole thing will
+	 * break. Hopefully, no one is crazy enough to design such arch.
+	 */
+	assert(psz % sizeof(bitmap_t) == 0);
+	psz /= sizeof(bitmap_t);
 
-	disk_b = (bitmap_t *)exfat->disk_bitmap;
-	alloc_b = (bitmap_t *)exfat->alloc_bitmap;
-	ohead_b = (bitmap_t *)exfat->ohead_bitmap;
+	bm_step = exfat->clus_size / sizeof(bitmap_t);
+	bm_step = MAX(bm_step, psz);
+	bm_step_bytes = bm_step * sizeof(bitmap_t);
+	assert(bm_step > 0);
 
-	for (i = 0; i < bitmap_bytes / sizeof(bitmap_t); i++)
-		ohead_b[i] = alloc_b[i] | disk_b[i];
+	for (size_t i = 0; i < bm_cnt; i += bm_step) {
+		bitmap_t v;
+		bool dirty = false;
+		size_t cnt = i + bm_step;
 
-	i = 0;
-	while (i < bitmap_bytes / sizeof(bitmap_t)) {
-		if (ohead_b[i] == disk_b[i]) {
-			i++;
-			continue;
+		cnt = MIN(cnt, bm_cnt);
+		for (size_t j = i; j < cnt; j += 1) {
+			v = alloc_b[j] | disk_b[j];
+			if (v != disk_b[j]) {
+				dirty = true;
+				disk_b[j] = v; /* BAM! Page fault! */
+			}
 		}
 
-		byte_offset = ((i * sizeof(bitmap_t)) / 512) * 512;
-		write_bytes = MIN(512, bitmap_bytes - byte_offset);
+		if (dirty) {
+			const size_t ofs = i * sizeof(bitmap_t);
+			const size_t rem = exfat->bm_len - ofs;
+			const size_t len = MIN(bm_step_bytes, rem);
 
-		if (!exfat_write_full(exfat->blk_dev->dev_fd,
-				(char *)ohead_b + byte_offset, write_bytes,
-				dev_offset + byte_offset))
-			return -EIO;
+			exfat_debug("dirty bitmap range: %zu:%zu\n", ofs, len);
 
-		i = (byte_offset + write_bytes) / sizeof(bitmap_t);
+			if (exfat->invalidate_disk_bitmap != NULL &&
+					!exfat->invalidate_disk_bitmap(exfat, ofs, len))
+				return -errno;
+		}
 	}
-	return 0;
 
+	if (exfat->sync_disk_bitmap != NULL && !exfat->sync_disk_bitmap(exfat))
+		return -errno;
+
+	return 0;
 }
 
 /*
@@ -1620,19 +1634,94 @@ static int read_lostfound(struct exfat *exfat, struct exfat_inode **lostfound)
 	return 0;
 }
 
-/* Create temporary files under LOST+FOUND and assign orphan
- * chains of clusters to these files.
+static struct exfat_inode *make_lostfound(struct exfat *exfat, int *err,
+		struct exfat_dentry_loc *loc, struct exfat_dentry **dset,
+		struct exfat_lookup_filter *lf, int *dcount, char *name)
+{
+	struct exfat_inode *ret = NULL;
+
+	*err = exfat_create_file(exfat, exfat->root, "LOST+FOUND", ATTR_SUBDIR);
+	if (*err) {
+		exfat_err("failed to create LOST+FOUND directory\n");
+		return NULL;
+	}
+
+	if (fsync(exfat->blk_dev->dev_fd) != 0) {
+		exfat_err("failed to sync()\n");
+		*err = -EIO;
+		return NULL;
+	}
+
+	*err = read_lostfound(exfat, &ret);
+	if (*err) {
+		exfat_err("failed to find LOST+FOUND\n");
+		return NULL;
+	}
+
+	/* get the last empty region of LOST+FOUND */
+	*err = exfat_lookup_dentry_set(exfat, ret, lf);
+	if (*err && *err != EOF) {
+		exfat_err("failed to find the last empty slot in LOST+FOUND\n");
+		return NULL;
+	}
+
+	loc->parent = ret;
+	loc->file_offset = lf->out.file_offset;
+	loc->dev_offset = lf->out.dev_offset;
+
+	/* build a template dentry set */
+	*err = exfat_build_file_dentry_set(exfat, name, 0, dset, dcount);
+	if (*err) {
+		exfat_err("failed to create a temporary file in LOST+FOUNDn");
+		return NULL;
+	}
+	(*dset)[1].dentry.stream.flags |= EXFAT_SF_CONTIGUOUS;
+
+	return ret;
+}
+
+static int make_orphan_file(struct exfat *exfat, struct exfat_inode **lostfound,
+		struct exfat_dentry_loc *loc, struct exfat_dentry **dset,
+		struct exfat_lookup_filter *lf, int *dcount, clus_t s_clu, clus_t e_clu)
+{
+	int ret;
+	char name[] = "FILE0000000.CHK";
+
+	exfat_err("ORPHAN: [%u, %u): ", s_clu, e_clu);
+
+	if (*lostfound == NULL) {
+		*lostfound = make_lostfound(exfat, &ret, loc, dset, lf, dcount, name);
+		if (*lostfound == NULL)
+			return ret;
+	}
+
+	snprintf(name, sizeof(name), "FILE%07d.CHK", (unsigned int)(loc->file_offset >> 5));
+
+	ret = exfat_update_file_dentry_set(exfat, *dset, *dcount, name, s_clu, e_clu - s_clu);
+	if (ret)
+		return ret;
+	ret = exfat_add_dentry_set(exfat, loc, *dset, *dcount, true);
+	if (ret)
+		return ret;
+
+	exfat_err("%s\n", name);
+
+	return 0;
+}
+
+/*
+ * Scan bitmaps for clusters which are not marked as free but not used in any
+ * files. Create a directory named "LOST+FOUND" and create temporary files in it
+ * to assign chains of orphan clusters to the files.
  */
 static int rescue_orphan_clusters(struct exfat_fsck *fsck)
 {
 	struct exfat *exfat = fsck->exfat;
-	struct exfat_inode *lostfound;
-	bitmap_t *disk_b, *alloc_b, *ohead_b;
-	struct exfat_dentry *dset;
-	clus_t clu_count, clu, s_clu, e_clu;
-	int err, dcount;
-	unsigned int i;
-	char name[] = "FILE0000000.CHK";
+	const clus_t clu_end = exfat->clus_count + EXFAT_FIRST_CLUSTER;
+	struct exfat_inode *lostfound = NULL;
+	struct exfat_dentry *dset = NULL;
+	clus_t s_clu = EXFAT_EOF_CLUSTER;
+	int err = 0, dcount;
 	struct exfat_dentry_loc loc;
 	struct exfat_lookup_filter lf = {
 		.in.type = EXFAT_INVAL,
@@ -1640,84 +1729,32 @@ static int rescue_orphan_clusters(struct exfat_fsck *fsck)
 		.in.filter = NULL,
 	};
 
-	clu_count = le32_to_cpu(exfat->bs->bsx.clu_count);
+	for (clus_t clu = EXFAT_FIRST_CLUSTER; clu < clu_end; clu++) {
+		const bool v =
+			exfat_bitmap_get(exfat->disk_bitmap, clu) &&
+			!exfat_bitmap_get(exfat->alloc_bitmap, clu);
 
-	/* find clusters which are not marked as free, but not allocated to
-	 * any files.
-	 */
-	disk_b = (bitmap_t *)exfat->disk_bitmap;
-	alloc_b = (bitmap_t *)exfat->alloc_bitmap;
-	ohead_b = (bitmap_t *)exfat->ohead_bitmap;
-	for (i = 0; i < EXFAT_BITMAP_SIZE(clu_count) / sizeof(bitmap_t); i++)
-		ohead_b[i] = disk_b[i] & ~alloc_b[i];
-
-	/* no orphan clusters */
-	if (exfat_bitmap_find_one(exfat, exfat->ohead_bitmap,
-				EXFAT_FIRST_CLUSTER, &s_clu))
-		return 0;
-
-	err = exfat_create_file(exfat_fsck.exfat,
-				exfat_fsck.exfat->root,
-				"LOST+FOUND",
-				ATTR_SUBDIR);
-	if (err) {
-		exfat_err("failed to create LOST+FOUND directory\n");
-		return err;
+		if (v) {
+			if (s_clu == EXFAT_EOF_CLUSTER)
+				s_clu = clu;
+		} else {
+			if (s_clu != EXFAT_EOF_CLUSTER) {
+				err = make_orphan_file(exfat, &lostfound, &loc, &dset,
+						       &lf, &dcount, s_clu, clu);
+				if (err)
+					goto out;
+				s_clu = EXFAT_EOF_CLUSTER;
+			}
+		}
+	}
+	if (s_clu != EXFAT_EOF_CLUSTER) {
+		/* Edge case: a run that stretches to the last cluster is not rescued */
+		err = make_orphan_file(exfat, &lostfound, &loc, &dset,
+				       &lf, &dcount, s_clu, clu_end);
 	}
 
-	if (fsync(exfat_fsck.exfat->blk_dev->dev_fd) != 0) {
-		exfat_err("failed to sync()\n");
-		return -EIO;
-	}
-
-	err = read_lostfound(exfat, &lostfound);
-	if (err) {
-		exfat_err("failed to find LOST+FOUND\n");
-		return err;
-	}
-
-	/* get the last empty region of LOST+FOUND */
-	err = exfat_lookup_dentry_set(exfat, lostfound, &lf);
-	if (err && err != EOF) {
-		exfat_err("failed to find the last empty slot in LOST+FOUND\n");
-		goto out;
-	}
-
-	loc.parent = lostfound;
-	loc.file_offset = lf.out.file_offset;
-	loc.dev_offset = lf.out.dev_offset;
-
-	/* build a template dentry set */
-	err = exfat_build_file_dentry_set(exfat, name, 0, &dset, &dcount);
-	if (err) {
-		exfat_err("failed to create a temporary file in LOST+FOUNDn");
-		goto out;
-	}
-	dset[1].dentry.stream.flags |= EXFAT_SF_CONTIGUOUS;
-
-	/* create temporary files and allocate contiguous orphan clusters
-	 * to each file.
-	 */
-	for (clu = EXFAT_FIRST_CLUSTER; clu < clu_count + EXFAT_FIRST_CLUSTER &&
-	     exfat_bitmap_find_one(exfat, exfat->ohead_bitmap, clu, &s_clu) == 0;) {
-		if (exfat_bitmap_find_zero(exfat, exfat->ohead_bitmap, s_clu, &e_clu))
-			e_clu = clu_count + EXFAT_FIRST_CLUSTER;
-		clu = e_clu;
-
-		snprintf(name, sizeof(name), "FILE%07d.CHK",
-			 (unsigned int)(loc.file_offset >> 5));
-		err = exfat_update_file_dentry_set(exfat, dset, dcount,
-						   name, s_clu, e_clu - s_clu);
-		if (err)
-			continue;
-		err = exfat_add_dentry_set(exfat, &loc, dset, dcount, true);
-		if (err)
-			continue;
-	}
-
-	free(dset);
-	err = 0;
 out:
+	free(dset);
 	exfat_free_inode(lostfound);
 	return err;
 }
@@ -2041,7 +2078,7 @@ int main(int argc, char * const argv[])
 		goto err;
 	}
 
-	exfat_fsck.exfat = exfat_alloc_exfat(&bd, bs, root);
+	exfat_fsck.exfat = exfat_alloc_exfat(&bd, bs, root, true);
 	if (!exfat_fsck.exfat) {
 		ret = -ENOMEM;
 		goto err;
@@ -2068,8 +2105,7 @@ int main(int argc, char * const argv[])
 
 	if (exfat_fsck.options & FSCK_OPTS_PROGRESS_BAR) {
 		used_clus_count = exfat_count_used_clusters(exfat_fsck.exfat->disk_bitmap,
-				(size_t)exfat_fsck.exfat->disk_bitmap_size,
-				exfat_fsck.exfat->clus_count);
+				exfat_fsck.exfat->bm_len, exfat_fsck.exfat->clus_count);
 		progress_init(&exfat_fsck.progress_bar, 0, used_clus_count, 0);
 	}
 

--- a/fsck/fsck.c
+++ b/fsck/fsck.c
@@ -2151,10 +2151,9 @@ err:
 	else
 		exit_code = FSCK_EXIT_NO_ERRORS;
 
-	if (exfat_fsck.buffer_desc)
+	if (exfat_fsck.exfat != NULL && exfat_fsck.buffer_desc != NULL)
 		exfat_free_buffer(exfat_fsck.exfat, exfat_fsck.buffer_desc);
-	if (exfat_fsck.exfat)
-		exfat_free_exfat(exfat_fsck.exfat);
+	exfat_free_exfat(exfat_fsck.exfat);
 
 	exfat_deinit_blk_dev_info(&bd);
 	deinit_fsck_user_input(&ui);

--- a/include/env.h
+++ b/include/env.h
@@ -8,5 +8,18 @@
 #define EXFAT_ENV_TTY_OVERRIDE		"EXFAT_TTY_OVERRIDE"
 #define EXFAT_ENV_SCRATCH_AMAP		"EXFAT_SCRATCH_AMAP"
 #define EXFAT_ENV_SCRATCH_AMAP_DEFAULT	"/var/tmp"
+#define EXFAT_ENV_MMAP			"EXFAT_MMAP"
+/* Allow mmap() in exfat_map_zeromem() and exfat_map_blankmem() */
+#define EXFAT_ENV_MMAP_MEMDEV		(0x01)
+/* Allow mmap() for allocation bitmap handling */
+#define EXFAT_ENV_MMAP_BITMAP		(0x02)
+/*
+ * Enable EXFAT_ENV_MMAP_BITMAP upon user's request.
+ *
+ * There's only one implementation of /dev/zero which is memdev but there are
+ * many different implementations backing blockdev, some of which may exhibit
+ * problematic behaviour when mmap()'d.
+ */
+#define EXFAT_ENV_MMAP_DEFAULT		(EXFAT_ENV_MMAP_MEMDEV)
 
 #endif /* !_EXFAT_ENV_H */

--- a/include/env.h
+++ b/include/env.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+
+#ifndef _EXFAT_ENV_H
+#define _EXFAT_ENV_H
+
+/* Influential env vars */
+
+#define EXFAT_ENV_TTY_OVERRIDE		"EXFAT_TTY_OVERRIDE"
+#define EXFAT_ENV_SCRATCH_AMAP		"EXFAT_SCRATCH_AMAP"
+#define EXFAT_ENV_SCRATCH_AMAP_DEFAULT	"/var/tmp"
+
+#endif /* !_EXFAT_ENV_H */

--- a/include/exfat_fs.h
+++ b/include/exfat_fs.h
@@ -7,6 +7,7 @@
 #ifndef _EXFAT_FS_H_
 #define _EXFAT_FS_H_
 
+#include <sys/types.h>
 #include "list.h"
 
 struct exfat_dentry;
@@ -105,6 +106,19 @@ struct exfat {
 	void (*free_disk_bitmap)(struct exfat *exfat);
 	/* Callback to free up `alloc_bitmap`(free() or munmap()) */
 	void (*free_alloc_bitmap)(struct exfat *exfat);
+
+	/*
+	 * The pid of the sentry process
+	 *
+	 * See SIGBUS Sentry Facilities for more.
+	 */
+	pid_t sentry_pid;
+	/*
+	 * The write end of the sentry pipe.
+	 *
+	 * See SIGBUS Sentry Facilities for more.
+	 */
+	int sentry_pipe;
 };
 
 struct exfat_dentry_loc {

--- a/include/exfat_fs.h
+++ b/include/exfat_fs.h
@@ -38,15 +38,73 @@ struct exfat {
 	clus_t			clus_count;
 	unsigned int		clus_size;
 	unsigned int		sect_size;
+	/* cached `sysconf(_SC_PAGE_SIZE)` */
+	long			pagesize;
+	/* Actual start address of memory allocated for `disk_bitmap` */
+	void			*disk_bitmap_m;
+	/* Actual size of `disk_bitmap_m` */
+	size_t			disk_bitmap_msize;
+	/*
+	 * Offset to the allocation bitmap on disk(for calloc() and read/write()
+	 * method)
+	 */
+	off_t			disk_bitmap_devofs;
+	/*
+	 * The allocation bitmap as stored on disk.
+	 *
+	 * Can be either a mmap()'d region of the block device or good-old
+	 * calloc()'d and read()'d from disk.
+	 */
 	unsigned char		*disk_bitmap;
+	/*
+	 * Ephemeral bitmap allocation for authoring a new allocation bitmap or
+	 * repairing the existing one.
+	 *
+	 * Can be either file-backed mapping or good-old calloc() memory.
+	 */
 	unsigned char		*alloc_bitmap;
-	unsigned char		*ohead_bitmap;
+	/*
+	 * The byte size of allocation bitmap(both `disk_bitmap` and
+	 * `alloc_bitmap`) in multiple of sizeof(bitmap_t). The valid length
+	 * could be less than this.
+	 *
+	 * Unfortunately, 'bitmap_size' is a macro define, hence the "bm_"
+	 * prefix.
+	 */
+	size_t			bm_size;
+	/*
+	 * The exact valid byte length of allocation bitmap.
+	 *
+	 * The size actually allocated may be much more than this and even
+	 * `bm_size` due to the page size alignment requirement of mmap().
+	 */
+	size_t			bm_len;
 	clus_t			disk_bitmap_clus;
-	unsigned int		disk_bitmap_size;
 	__u16			*upcase_table;
 	clus_t			start_clu;
 	unsigned int		buffer_count;
 	struct buffer_desc	*lookup_buffer; /* for dentry set lookup */
+
+	/*
+	 * Callback after changing the contents of `disk_bitmap`.
+	 *
+	 * If `disk_bitmap` is regular calloc()'d memory and its contents read()
+	 * from the disk, write() will be done in the function. If the address
+	 * is mmap()'d, this is NULL because write() is handled in kernel.
+	 */
+	bool (*invalidate_disk_bitmap)(struct exfat *exfat, size_t ofs, size_t len);
+	/*
+	 * Callback for requesting sync of `disk_bitmap`.
+	 *
+	 * Currently, this is only set for mmap()'d `disk_bitmap` to msync()
+	 * the dirty pages. It's NULL otherwise because fsync() is issued
+	 * elsewhere prior to process exit.
+	 */
+	bool (*sync_disk_bitmap)(struct exfat *exfat);
+	/* Callback to free up `disk_bitmap`(free() or munmap()) */
+	void (*free_disk_bitmap)(struct exfat *exfat);
+	/* Callback to free up `alloc_bitmap`(free() or munmap()) */
+	void (*free_alloc_bitmap)(struct exfat *exfat);
 };
 
 struct exfat_dentry_loc {
@@ -69,7 +127,7 @@ struct buffer_desc {
 };
 
 struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs,
-				 struct exfat_inode *root);
+		struct exfat_inode *root, const bool need_amap);
 void exfat_free_exfat(struct exfat *exfat);
 
 struct exfat_inode *exfat_alloc_inode(__u16 attr);
@@ -86,6 +144,8 @@ int exfat_resolve_path_parent(struct path_resolve_ctx *ctx,
 
 struct buffer_desc *exfat_alloc_buffer(struct exfat *exfat);
 void exfat_free_buffer(const struct exfat *exfat, struct buffer_desc *bd);
+
+bool exfat_load_disk_bitmap(struct exfat *exfat, const off_t loc, const bool rw);
 
 static inline unsigned int exfat_get_read_size(const struct exfat *exfat)
 {

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -401,6 +401,14 @@ void exfat_put_bootstrap_code(const char *user_msg, void *dst, unsigned int code
 bool exfat_isatty_stdio(void);
 
 /*
+ * Do getenv(EXFAT_ENV_MMAP) and parse the string.
+ *
+ * Returns a positive integer value if the env var is set to a valid string.
+ * -1 otherwise.
+ */
+int exfat_getenv_mmap(void);
+
+/*
  * Exfat Print
  */
 

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -329,8 +329,11 @@ void exfat_close_fd_devzero(void);
  * EBADFD if exfat_open_fd_devzero() has been called successfully, or any other
  * errno set in mmap().
  *
- * Note that /dev/zero mapping do not count towards committed memory. See
- * vm.overcommit for detail.
+ * Note that /dev/zero mappings do not count towards committed memory. See
+ * vm.overcommit for detail. /dev/zero is used instead of MAP_ANONYMOUS for
+ * portability reasons(the behaviour of shared read-only anonymous mapping is
+ * not well-defined). However, on Linux, it should be equivalent to allocating
+ * memory through MAP_ANONYMOUS.
  *
  * For rw version of this function, see exfat_map_blankmem().
  */
@@ -340,7 +343,8 @@ const void *exfat_map_zeromem(const size_t len, bool *mapped);
  * zeros(e.g. allocation bitmap).
  *
  * The function has the exact same semantics as exfat_map_zeromem(), except that
- * it calls mmap() with PROT_READ|PROT_WRITE and MAP_PRIVATE.
+ * it calls mmap() with PROT_READ|PROT_WRITE and MAP_PRIVATE|MAP_NORESERVE if
+ * and only if supported by the platform.
  */
 void *exfat_map_blankmem(const size_t len, bool *mapped);
 /*

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -433,4 +433,8 @@ extern unsigned int print_level;
 			(guid)[8], (guid)[9], (guid)[10], (guid)[11],	\
 			(guid)[12], (guid)[13], (guid)[14], (guid)[15])
 
+/* Influential env vars */
+#define EXFAT_ENV_SCRATCH_AMAP		"EXFAT_SCRATCH_AMAP"
+#define EXFAT_ENV_SCRATCH_AMAP_DEFAULT	"/var/tmp"
+
 #endif /* !_LIBEXFAT_H */

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -433,8 +433,4 @@ extern unsigned int print_level;
 			(guid)[8], (guid)[9], (guid)[10], (guid)[11],	\
 			(guid)[12], (guid)[13], (guid)[14], (guid)[15])
 
-/* Influential env vars */
-#define EXFAT_ENV_SCRATCH_AMAP		"EXFAT_SCRATCH_AMAP"
-#define EXFAT_ENV_SCRATCH_AMAP_DEFAULT	"/var/tmp"
-
 #endif /* !_LIBEXFAT_H */

--- a/label/label.c
+++ b/label/label.c
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 	} else {
 		struct exfat *exfat;
 
-		exfat = exfat_alloc_exfat(&bd, NULL, NULL);
+		exfat = exfat_alloc_exfat(&bd, NULL, NULL, false);
 		if (!exfat) {
 			ret = -ENOMEM;
 			goto out;

--- a/lib/exfat_dir.c
+++ b/lib/exfat_dir.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <time.h>
 #include <inttypes.h>
+#include <assert.h>
 
 #include "exfat_ondisk.h"
 #include "libexfat.h"
@@ -776,6 +777,8 @@ int exfat_update_file_dentry_set(struct exfat *exfat,
 static int __find_free_cluster(struct exfat *exfat, clus_t *new_clu,
 		clus_t start, clus_t end)
 {
+	assert(exfat->alloc_bitmap != NULL);
+
 	while (start < end) {
 		if (exfat_bitmap_find_zero(exfat, exfat->alloc_bitmap,
 					   start, new_clu))
@@ -938,7 +941,7 @@ int exfat_alloc_cluster(struct exfat *exfat, struct exfat_inode *inode,
 	err = find_free_cluster(exfat, exfat->start_clu, new_clu);
 	if (err) {
 		exfat->start_clu = EXFAT_FIRST_CLUSTER;
-		exfat_err("failed to find an free cluster\n");
+		exfat_err("failed to find a free cluster\n");
 		return -ENOSPC;
 	}
 	exfat->start_clu = *new_clu;

--- a/lib/exfat_fs.c
+++ b/lib/exfat_fs.c
@@ -15,6 +15,8 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <signal.h>
+#include <sys/wait.h>
 #ifdef _POSIX_MAPPED_FILES
 #include <sys/mman.h>
 #endif
@@ -120,6 +122,16 @@ void exfat_free_exfat(struct exfat *exfat)
 	free(exfat->bs);
 	exfat->bs = NULL;
 
+	if (exfat->sentry_pid > 0) {
+		struct sigaction sa = { .sa_handler = SIG_DFL, };
+
+		sigaction(SIGBUS, &sa, NULL);
+		close(exfat->sentry_pipe);
+		waitpid(exfat->sentry_pid, NULL, 0);
+		exfat->sentry_pipe = -1;
+		exfat->sentry_pid = -1;
+	}
+
 	if (exfat->free_disk_bitmap != NULL) {
 		exfat->free_disk_bitmap(exfat);
 		exfat->free_disk_bitmap = NULL;
@@ -146,6 +158,178 @@ static bool bitmap_mmap_allowed(void)
 {
 	return exfat_getenv_mmap() & EXFAT_ENV_MMAP_BITMAP;
 }
+
+#ifdef _POSIX_MAPPED_FILES
+/*
+ * SIGBUS Sentry Facilities
+ *
+ * Since printf() cannot be used in a signal handler, if choosing to mmap() to
+ * access the data on disks, spawn a child process("the sentry"), whose sole
+ * purpose is to print error messages on behalf of the parent process in case of
+ * SIGBUS caused by access to exfat->alloc_bitmap or exfat->disk_bitmap.
+ *
+ * Upon receiving SIGBUS in the parent, the information parsed off siginfo_t is
+ * merely passed to the child process where it's printed. We don't write() to
+ * STDERR_FILENO directly from the signal handler in the main process because
+ * the locale might be other than "C" or UTF-8!
+ *
+ * Most other utils don't bother handling SIGBUS. We go through all this trouble
+ * because this is filesystem utils - we have our duty of reporting faulty
+ * hardware.
+ */
+
+enum sentry_alert_type {
+	SENTRY_ALERT_TYPE_NONE,
+	SENTRY_ALERT_TYPE_AMAP,
+	SENTRY_ALERT_TYPE_DISKMAP,
+};
+
+struct sentry_alert {
+	off_t devofs;
+	enum sentry_alert_type type;
+};
+
+/* Thankfully, gcc doesn't over optimise this with -O2. */
+/* volatile */
+static struct exfat *exfat_sentry; /* ¯\_(ツ)_/¯ */
+
+static void handle_sigbus(int signum, siginfo_t *info, void *uctx)
+{
+	int saved_errno;
+	uintptr_t a, b, c;
+	struct sentry_alert sa = { 0, };
+
+	assert(signum == SIGBUS);
+	assert(exfat_sentry != NULL);
+	assert(exfat_sentry->sentry_pid > 0);
+	assert(exfat_sentry->sentry_pipe >= 0);
+	b = (uintptr_t)info->si_addr;
+
+	a = (uintptr_t)exfat_sentry->alloc_bitmap;
+	c = a + exfat_sentry->bm_size;
+	if (a <= b && b < c) {
+		sa.type = SENTRY_ALERT_TYPE_AMAP;
+		goto handled;
+	}
+
+	a = (uintptr_t)exfat_sentry->disk_bitmap_m;
+	c = a + exfat_sentry->bm_size;
+	if (a <= b && b < c) {
+		sa.type = SENTRY_ALERT_TYPE_DISKMAP;
+		sa.devofs = exfat_sentry->disk_bitmap_devofs;
+		goto handled;
+	}
+
+	/* Not our concern. */
+	/* Since SA_RESETHAND is set, the subsequent SIGBUS will trigger the default action. */
+	return;
+
+handled:
+	saved_errno = errno;
+	/*
+	 * This is only an approximation: the exact block number is probably not
+	 * known because the kernel would have encountered -EIO whilst faulting
+	 * the entire page. At least in Linux, info->si_addr always seems to be
+	 * aligned to the page boundary.
+	 */
+	sa.devofs += (off_t)(b - a);
+
+	write(exfat_sentry->sentry_pipe, &sa, sizeof(sa));
+	close(exfat_sentry->sentry_pipe);
+	waitpid(exfat_sentry->sentry_pid, NULL, 0);
+
+	errno = saved_errno;
+}
+
+/* __attribute__((noreturn)) */
+static void sentry_process_main(int fd)
+{
+	struct sentry_alert sa;
+	const char *what, *blinker_start, *blinkder_end;
+	ssize_t rsize;
+
+	rsize = read(fd, &sa, sizeof(sa));
+	if (rsize == sizeof(sa)) {
+		switch (sa.type) {
+		case SENTRY_ALERT_TYPE_AMAP:
+			what = getenv(EXFAT_ENV_SCRATCH_AMAP);
+			break;
+		case SENTRY_ALERT_TYPE_DISKMAP:
+			what = "(target device)";
+			break;
+		default:
+			what = NULL;
+		}
+		assert(what != NULL);
+
+		if (isatty(STDERR_FILENO)) {
+			blinker_start = "\033[5m";
+			blinkder_end = "\033[0m";
+		} else {
+			blinker_start = "";
+			blinkder_end = "";
+		}
+
+		exfat_err("\n%s: SIGBUS(I/O error) triggered accessing offset 0x%llx\n",
+			what, (unsigned long long)sa.devofs);
+		exfat_err("!!! %sCrashing due to faulty hardware%s !!!\n"
+			  "Please check the kernel messages for errors.\n\n",
+			  blinker_start, blinkder_end);
+	} else
+		assert(rsize == 0);
+
+	exit(EXIT_SUCCESS);
+}
+
+static bool setup_sigbus_sentry(struct exfat *exfat)
+{
+	int fd[2];
+
+	if (exfat->sentry_pid > 0)
+		/* Already running. */
+		return true;
+
+	if (pipe(fd) < 0)
+		return false;
+
+	exfat_debug("fork()'ing... (parent pid: %d)\n", (int)getpid());
+	fflush(stdout);
+	fflush(stderr);
+	exfat->sentry_pid = fork();
+	if (exfat->sentry_pid < 0)
+		goto bail;
+	else if (exfat->sentry_pid == 0) {
+		close(fd[1]);
+		sentry_process_main(fd[0]);
+		/* unreachable */
+		abort();
+	} else {
+		struct sigaction sa = {
+			.sa_sigaction = handle_sigbus,
+			.sa_flags = SA_RESETHAND | SA_SIGINFO,
+		};
+		int err;
+
+		exfat_debug("sentry pid: %d\n", (int)exfat->sentry_pid);
+
+		close(fd[0]);
+		exfat->sentry_pipe = fd[1];
+		exfat_sentry = exfat;
+
+		err = sigaction(SIGBUS, &sa, NULL);
+		(void)err;
+		assert(err == 0);
+	}
+
+	return true;
+bail:
+	exfat_err("%s(): %s\n", __func__, strerror(errno));
+	close(fd[0]);
+	close(fd[1]);
+
+	return false;
+}
+#endif
 
 #if defined(_POSIX_MAPPED_FILES) && defined(O_TMPFILE)
 static void unmap_amap(struct exfat *exfat)
@@ -187,6 +371,9 @@ static bool open_tmp_amap(struct exfat *exfat)
 		errno = EPERM;
 		return false;
 	}
+
+	if (!setup_sigbus_sentry(exfat))
+		return false;
 
 	fd = open(path, O_TMPFILE | O_RDWR, 0600);
 	if (fd < 0)
@@ -263,6 +450,8 @@ struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs,
 	exfat->bm_len = DIV_ROUND_UP(exfat->clus_count, 8);
 	exfat->root = root;
 	exfat->pagesize = sysconf(_SC_PAGE_SIZE);
+	exfat->sentry_pid = -1;
+	exfat->sentry_pipe = -1;
 
 	assert(exfat->clus_count > 0);
 	assert(exfat->pagesize > 0);
@@ -370,7 +559,8 @@ bool exfat_load_disk_bitmap(struct exfat *exfat, const off_t loc, const bool rw)
 #ifdef _POSIX_MAPPED_FILES
 	const off_t req_size = loc + exfat->bm_size;
 
-	if (bitmap_mmap_allowed() && req_size > 0 && exfat->blk_dev->size >= req_size) {
+	if (bitmap_mmap_allowed() && setup_sigbus_sentry(exfat) && req_size > 0 &&
+			exfat->blk_dev->size >= req_size) {
 		const int prot = rw ? PROT_READ | PROT_WRITE : PROT_READ;
 		const off_t pa_ofs = loc & ~((off_t)exfat->pagesize - 1);
 		const size_t odelta = (size_t)(loc - pa_ofs);

--- a/lib/exfat_fs.c
+++ b/lib/exfat_fs.c
@@ -5,10 +5,19 @@
  *   Author(s): Hyunchul Lee <hyc.lee@gmail.com>
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 #include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#ifdef _POSIX_MAPPED_FILES
+#include <sys/mman.h>
+#endif
 
 #include "exfat_ondisk.h"
 #include "libexfat.h"
@@ -108,19 +117,111 @@ void exfat_free_exfat(struct exfat *exfat)
 		return;
 
 	free(exfat->bs);
-	free(exfat->alloc_bitmap);
-	free(exfat->disk_bitmap);
-	free(exfat->ohead_bitmap);
+	exfat->bs = NULL;
+
+	if (exfat->free_disk_bitmap != NULL) {
+		exfat->free_disk_bitmap(exfat);
+		exfat->free_disk_bitmap = NULL;
+	}
+	if (exfat->free_alloc_bitmap != NULL) {
+		exfat->free_alloc_bitmap(exfat);
+		exfat->free_alloc_bitmap = NULL;
+	}
+
 	free(exfat->upcase_table);
+	exfat->upcase_table = NULL;
+
 	exfat_free_inode(exfat->root);
+	exfat->root = NULL;
+
 	if (exfat->lookup_buffer)
 		exfat_free_buffer(exfat, exfat->lookup_buffer);
+	exfat->lookup_buffer = NULL;
 
 	free(exfat);
 }
 
+#if defined(_POSIX_MAPPED_FILES) && defined(O_TMPFILE)
+static void unmap_amap(struct exfat *exfat)
+{
+	munmap(exfat->alloc_bitmap, exfat->bm_size);
+	exfat->alloc_bitmap = NULL;
+}
+#endif
+
+/*
+ * Create an unnamed temporary file(O_TMPFILE) that only persists with the
+ * process, allocate space needed, and then mmap() it as alloc_bitmap.
+ *
+ * By default, the temporary file is created in /var/tmp. The path can be
+ * overridden with the influential environment variable 'EXFAT_SCRATCH_AMAP'.
+ * Setting it as an empty string disables this feature.
+ *
+ * NOTE that the idea of falling back to mkstemp() is abandoned because it is
+ * impossible to guarantee the deletion of the temp file created that way -
+ * there's a short window of opportunity between mkstemp() and unlink() where
+ * the process can die.
+ */
+static bool open_tmp_amap(struct exfat *exfat)
+{
+	bool ret = false;
+#if defined(_POSIX_MAPPED_FILES) && defined(O_TMPFILE)
+	const char *path = getenv(EXFAT_ENV_SCRATCH_AMAP);
+	int fd;
+
+	if (path == NULL)
+		path = EXFAT_ENV_SCRATCH_AMAP_DEFAULT;
+	else if (path[0] == 0)
+		return false;
+
+	fd = open(path, O_TMPFILE | O_RDWR, 0600);
+	if (fd < 0)
+		goto out;
+
+	if (fallocate(fd, 0, 0, exfat->bm_size) == 0) {
+		void *m = mmap(NULL, exfat->bm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+
+		if (m != MAP_FAILED) {
+			ret = true;
+			exfat->alloc_bitmap = m;
+			exfat->free_alloc_bitmap = unmap_amap;
+			exfat_debug("amap: opened O_TMPFILE at %s\n", path);
+			goto out;
+		}
+	}
+out:
+	if (!ret)
+		exfat_debug("%s: %s\n", path, strerror(errno));
+	if (fd >= 0)
+		close(fd);
+#endif
+	return ret;
+}
+
+static void free_amap(struct exfat *exfat)
+{
+	free(exfat->alloc_bitmap);
+	exfat->alloc_bitmap = NULL;
+}
+
+/*
+ * Allocate alloc_bitmap in the traditional dynamic heap memory.
+ */
+static bool alloc_amap(struct exfat *exfat)
+{
+	exfat->alloc_bitmap = calloc(1, exfat->bm_size);
+
+	if (exfat->alloc_bitmap != NULL) {
+		exfat->free_alloc_bitmap = free_amap;
+		exfat_debug("amap: calloc()'d\n");
+		return true;
+	}
+
+	return false;
+}
+
 struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs,
-		struct exfat_inode *root)
+		struct exfat_inode *root, const bool need_amap)
 {
 	struct exfat *exfat;
 
@@ -144,25 +245,20 @@ struct exfat *exfat_alloc_exfat(struct exfat_blk_dev *blk_dev, struct pbr *bs,
 	exfat->clus_count = le32_to_cpu(bs->bsx.clu_count);
 	exfat->clus_size = EXFAT_CLUSTER_SIZE(bs);
 	exfat->sect_size = EXFAT_SECTOR_SIZE(bs);
+	exfat->bm_size = EXFAT_BITMAP_SIZE(exfat->clus_count);
+	exfat->bm_len = DIV_ROUND_UP(exfat->clus_count, 8);
 	exfat->root = root;
+	exfat->pagesize = sysconf(_SC_PAGE_SIZE);
 
-	/* TODO: bitmap could be very large. */
-	exfat->alloc_bitmap = calloc(1, EXFAT_BITMAP_SIZE(exfat->clus_count));
-	if (!exfat->alloc_bitmap) {
-		exfat_err("failed to allocate bitmap\n");
-		goto err;
-	}
+	assert(exfat->clus_count > 0);
+	assert(exfat->pagesize > 0);
+	assert(exfat->bm_size >= exfat->bm_len);
 
-	exfat->ohead_bitmap = calloc(1, EXFAT_BITMAP_SIZE(exfat->clus_count));
-	if (!exfat->ohead_bitmap) {
-		exfat_err("failed to allocate bitmap\n");
-		goto err;
-	}
-
-	exfat->disk_bitmap = calloc(1, EXFAT_BITMAP_SIZE(exfat->clus_count));
-	if (!exfat->disk_bitmap) {
-		exfat_err("failed to allocate bitmap\n");
-		goto err;
+	if (need_amap) {
+		if (!(open_tmp_amap(exfat) || alloc_amap(exfat))) {
+			exfat_err("failed to allocate bitmap\n");
+			goto err;
+		}
 	}
 
 	exfat->buffer_count = ((MAX_EXT_DENTRIES + 1) * DENTRY_SIZE) /
@@ -222,6 +318,84 @@ void exfat_free_buffer(const struct exfat *exfat, struct buffer_desc *bd)
 			free(bd[i].buffer);
 	}
 	free(bd);
+}
+
+#ifdef _POSIX_MAPPED_FILES
+static bool msync_disk_bitmap(struct exfat *exfat)
+{
+	return msync(exfat->disk_bitmap_m, exfat->disk_bitmap_msize, MS_SYNC) == 0;
+}
+
+static void unmap_disk_bitmap(struct exfat *exfat)
+{
+	munmap(exfat->disk_bitmap_m, exfat->disk_bitmap_msize);
+	exfat->disk_bitmap = exfat->disk_bitmap_m = NULL;
+	exfat->disk_bitmap_msize = 0;
+}
+#endif
+
+static bool write_disk_bitmap(struct exfat *exfat, size_t ofs, size_t len)
+{
+	return exfat_write_full(exfat->blk_dev->dev_fd, exfat->disk_bitmap + ofs,
+				len, exfat->disk_bitmap_devofs + ofs);
+}
+
+static void free_disk_bitmap(struct exfat *exfat)
+{
+	free(exfat->disk_bitmap);
+	exfat->disk_bitmap = exfat->disk_bitmap_m = NULL;
+}
+
+/*
+ * Either map the allocation bitmap region on the disk to the address space or
+ * allocate memory and read the allocation bitmap from the disk.
+ */
+bool exfat_load_disk_bitmap(struct exfat *exfat, const off_t loc, const bool rw)
+{
+	void *m;
+#ifdef _POSIX_MAPPED_FILES
+	const off_t req_size = loc + exfat->bm_size;
+	const int prot = rw ? PROT_READ | PROT_WRITE : PROT_READ;
+
+	if (req_size > 0 && exfat->blk_dev->size >= req_size) {
+		const off_t pa_ofs = loc & ~((off_t)exfat->pagesize - 1);
+		const size_t odelta = (size_t)(loc - pa_ofs);
+		const size_t msize = exfat->bm_size + odelta;
+
+		assert(msize >= exfat->bm_size);
+
+		m = mmap(NULL, msize, prot, MAP_SHARED, exfat->blk_dev->dev_fd, pa_ofs);
+		if (m != MAP_FAILED) {
+			exfat->disk_bitmap = exfat->disk_bitmap_m = m;
+			exfat->disk_bitmap += odelta;
+			exfat->disk_bitmap_msize = msize;
+			exfat->disk_bitmap_devofs = loc;
+			exfat->invalidate_disk_bitmap = NULL;
+			exfat->sync_disk_bitmap = rw ? msync_disk_bitmap : NULL;
+			exfat->free_disk_bitmap = unmap_disk_bitmap;
+
+			exfat_debug("dmap: mmap()'d\n");
+			return true;
+		}
+
+		exfat_debug("mmap(): %s\n", strerror(errno));
+	}
+#endif
+	m = calloc(1, exfat->bm_size);
+	if (m != NULL && exfat_read_full(exfat->blk_dev->dev_fd, m, exfat->bm_len, loc)) {
+		exfat->disk_bitmap = exfat->disk_bitmap_m = m;
+		exfat->disk_bitmap_msize = exfat->bm_size;
+		exfat->disk_bitmap_devofs = loc;
+		exfat->invalidate_disk_bitmap = write_disk_bitmap;
+		exfat->sync_disk_bitmap = NULL;
+		exfat->free_disk_bitmap = free_disk_bitmap;
+
+		exfat_debug("dmap: calloc() & read()\n");
+		return true;
+	}
+
+	free(m);
+	return false;
 }
 
 /*

--- a/lib/exfat_fs.c
+++ b/lib/exfat_fs.c
@@ -142,6 +142,11 @@ void exfat_free_exfat(struct exfat *exfat)
 	free(exfat);
 }
 
+static bool bitmap_mmap_allowed(void)
+{
+	return exfat_getenv_mmap() & EXFAT_ENV_MMAP_BITMAP;
+}
+
 #if defined(_POSIX_MAPPED_FILES) && defined(O_TMPFILE)
 static void unmap_amap(struct exfat *exfat)
 {
@@ -167,13 +172,21 @@ static bool open_tmp_amap(struct exfat *exfat)
 {
 	bool ret = false;
 #if defined(_POSIX_MAPPED_FILES) && defined(O_TMPFILE)
-	const char *path = getenv(EXFAT_ENV_SCRATCH_AMAP);
+	const char *path;
 	int fd;
 
+	if (!bitmap_mmap_allowed()) {
+		errno = EPERM;
+		return false;
+	}
+
+	path = getenv(EXFAT_ENV_SCRATCH_AMAP);
 	if (path == NULL)
 		path = EXFAT_ENV_SCRATCH_AMAP_DEFAULT;
-	else if (path[0] == 0)
+	else if (path[0] == 0) {
+		errno = EPERM;
 		return false;
+	}
 
 	fd = open(path, O_TMPFILE | O_RDWR, 0600);
 	if (fd < 0)
@@ -356,9 +369,9 @@ bool exfat_load_disk_bitmap(struct exfat *exfat, const off_t loc, const bool rw)
 	void *m;
 #ifdef _POSIX_MAPPED_FILES
 	const off_t req_size = loc + exfat->bm_size;
-	const int prot = rw ? PROT_READ | PROT_WRITE : PROT_READ;
 
-	if (req_size > 0 && exfat->blk_dev->size >= req_size) {
+	if (bitmap_mmap_allowed() && req_size > 0 && exfat->blk_dev->size >= req_size) {
+		const int prot = rw ? PROT_READ | PROT_WRITE : PROT_READ;
 		const off_t pa_ofs = loc & ~((off_t)exfat->pagesize - 1);
 		const size_t odelta = (size_t)(loc - pa_ofs);
 		const size_t msize = exfat->bm_size + odelta;

--- a/lib/exfat_fs.c
+++ b/lib/exfat_fs.c
@@ -24,6 +24,7 @@
 
 #include "exfat_fs.h"
 #include "exfat_dir.h"
+#include "env.h"
 
 struct exfat_inode *exfat_alloc_inode(__u16 attr)
 {

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -1303,9 +1303,9 @@ void *exfat_map_blankmem(const size_t len, bool *mapped)
 	int prot = -1;
 	int flags = -1;
 
-#ifdef _POSIX_MAPPED_FILES
+#if defined(_POSIX_MAPPED_FILES) && defined(MAP_NORESERVE)
 	prot = PROT_READ|PROT_WRITE;
-	flags = MAP_PRIVATE;
+	flags = MAP_PRIVATE|MAP_NORESERVE;
 #endif
 	return exfat_do_map_zerodev(len, mapped, prot, flags);
 }

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -1233,12 +1233,15 @@ out:
 
 int exfat_open_fd_devzero(void)
 {
+	if (fd_devzero >= 0)
+		return 0;
 #ifdef _POSIX_MAPPED_FILES
-	if (fd_devzero < 0) {
+	if (exfat_getenv_mmap() & EXFAT_ENV_MMAP_MEMDEV) {
 		fd_devzero = open("/dev/zero", O_RDONLY);
 		if (fd_devzero < 0)
 			return -errno;
-	}
+	} else
+		return -EPERM;
 #else
 	return -ENOSYS;
 #endif
@@ -1981,4 +1984,17 @@ bool exfat_isatty_stdio(void)
 	}
 
 	return isatty(STDIN_FILENO) && isatty(STDOUT_FILENO);
+}
+
+int exfat_getenv_mmap(void)
+{
+	const char *envvar = getenv(EXFAT_ENV_MMAP);
+	int ret = -1;
+
+	if (envvar != NULL)
+		sscanf(envvar, "%d", &ret);
+	if (ret < 0)
+		ret = EXFAT_ENV_MMAP_DEFAULT;
+
+	return ret;
 }

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -30,6 +30,7 @@
 #include "version.h"
 #include "exfat_fs.h"
 #include "exfat_dir.h"
+#include "env.h"
 
 unsigned int print_level  = EXFAT_INFO;
 static int fd_devzero = -1;
@@ -1970,7 +1971,7 @@ void exfat_put_bootstrap_code(const char *user_msg, void *dst, unsigned int code
 
 bool exfat_isatty_stdio(void)
 {
-	const char *env = getenv("EXFAT_TTY_OVERRIDE");
+	const char *env = getenv(EXFAT_ENV_TTY_OVERRIDE);
 
 	if (env != NULL) {
 		int v = -1;

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -1664,10 +1664,11 @@ int exfat_root_clus_count(struct exfat *exfat)
 
 	clus = node->first_clus;
 	do {
-		if (exfat_bitmap_get(exfat->alloc_bitmap, clus))
-			return -EINVAL;
-
-		exfat_bitmap_set(exfat->alloc_bitmap, clus);
+		if (exfat->alloc_bitmap != NULL) {
+			if (exfat_bitmap_get(exfat->alloc_bitmap, clus))
+				return -EINVAL;
+			exfat_bitmap_set(exfat->alloc_bitmap, clus);
+		}
 
 		if (exfat_get_inode_next_clus(exfat, node, clus, &next)) {
 			exfat_err("ERROR: failed to read the fat entry of root");

--- a/manpages/chdosattr.1
+++ b/manpages/chdosattr.1
@@ -63,7 +63,7 @@ The modification of the DOS attribute \fBs\fP(SYSTEM) requires
 For obvious reasons, the DOS attributes \fBs\fP(DIRECTORY) and \fBv\fP(VOLUME)
 cannot be altered.
 
-.SH NOTE
+.SH NOTES
 .P
 In vFAT, exFAT and NTFS, only the READONLY attribute is controlled through owner
 write permission bit. Linux kernel always sets ARCHIVE on files it creates and

--- a/manpages/defrag.exfat.8
+++ b/manpages/defrag.exfat.8
@@ -41,6 +41,14 @@ Display version information and exit.
 .B \-h, \-\-help
 Show usage information and exit.
 
+.SH ENVIRONMENT
+Following influential environment variables can be used to reduce memory
+footprint. See \fBexfatprogs-env\fP(7) for detail.
+.IP
+\fBEXFAT_MMAP\fR="3"
+.IP
+\fBEXFAT_SCRATCH_AMAP\fR="/var/tmp"
+
 .SH EXAMPLES
 .PP
 Defragment an unmounted exFAT device (with safety warning):

--- a/manpages/dump.exfat.8
+++ b/manpages/dump.exfat.8
@@ -20,9 +20,6 @@ dump.exfat \- Show on-disk information of exfat filesystem
 .SH DESCRIPTION
 .B dump.exfat
 Print on-disk information from given device that formatted by exFAT filesystem.
-
-Note: For printing information of directory entries, the absence of "double-link" does not indicate the cluster is not doubly allocated if the scan is not started from the root directory with the recursive option.
-
 .PP
 .SH OPTIONS
 .TP
@@ -40,3 +37,14 @@ Scan and print information of directory entries from a given path recursively th
 .TP
 .BR \-c ", " \-\-cluster-chain
 Print the cluster chain while printing the directory entry information. Only works with -d/-s option.
+.SH ENVIRONMENT
+Following influential environment variables can be used to reduce memory
+footprint. See \fBexfatprogs-env\fP(7) for detail.
+.IP
+\fBEXFAT_MMAP\fR="3"
+.IP
+\fBEXFAT_SCRATCH_AMAP\fR="/var/tmp"
+.SH NOTES
+For printing information of directory entries, the absence of "double-link" does
+not indicate the cluster is not doubly allocated if the scan is not started from
+the root directory with the recursive option.

--- a/manpages/exfat2img.8
+++ b/manpages/exfat2img.8
@@ -24,6 +24,14 @@ Because a dump image generated from stdout has a special format, when restoring 
 .B \-V
 Prints the version number and exits.
 
+.SH ENVIRONMENT
+Following influential environment variables can be used to reduce memory
+footprint. See \fBexfatprogs-env\fP(7) for detail.
+.IP
+\fBEXFAT_MMAP\fR="3"
+.IP
+\fBEXFAT_SCRATCH_AMAP\fR="/var/tmp"
+
 .SH EXAMPLES
 .PP
 Dump metadata into a sparse file.

--- a/manpages/exfatprogs-env.7
+++ b/manpages/exfatprogs-env.7
@@ -1,0 +1,44 @@
+.TH EXFATPROGS-ENV 7
+.SH NAME
+exfatprogs\-env \- exfatprogs influential environment variables
+.SH DESCRIPTION
+exfatprogs executables use environment variables to override the compiled\-in
+default settings.
+.TP
+.BR EXFAT_SCRATCH_AMAP
+Specifies the path to the temporary directory in which a temporary file(aka.
+"scratch file") for storing a copy of allocation bitmap is created by the
+programs \fBfsck.exfat\fP(8), \fBexfat2img\fP(8) and \fBdefrag.exfat\fP(8).
+Defaults to \fI/var/tmp\fP. Specifying an empty string disables this feature.
+
+To enable, the second least significant bit(\fI0x02\fP) of \fBEXFAT_MMAP\fP also
+needs to be set. For stability reasons, the temporary file is only created using
+\fBO_TMPFILE\fP flag(\fBopen\fP(2)) so it requires the support of the underlying
+filesystem. Failures are silently ignored and the programs fallback to the
+traditional file I/O.
+.TP
+.BR EXFAT_MMAP
+Specifies the \fBmmap\fP(2) usage control bits. Defaults to \fI"1"\fP.
+
+With large exFAT volumes, the allocation bitmaps can range up to 512MB. It may
+be unfeasible or even impossible to use exfatprogs utilities on large volumes on
+memory constraint systems. To overcome this limitation, allocation bitmap
+handling through file-backed shared mappings has been implemented to make it
+possible to use large exFAT volumes on systems constraint in memory but equipped
+with MMU(memory management unit).
+
+The first least significant bit(\fI0x01\fP) controls the use of \fI/dev/zero\fP
+in \fBmkfs.exfat\fP(8). The second least significant bit(\fI0x02\fP) controls
+mapping of the allocation bitmaps in the target device and the scratch
+file(\fBEXFAT_SCRATCH_AMAP\fP). To enable both of these features to reduce
+memory use, specify \fI"3"\fP. Specifying \fI"0"\fP disables the use of file
+mapping entirely in all of the programs.
+
+As per mapping \fI/dev/zero\fP, the \fBMAP_NORESERVE\fP support is required in order
+for the environment variable to have an effect.
+.TP
+.BR EXFAT_TTY_OVERRIDE
+Overrides \fBisatty\fP(3) return values for the standard input and output.
+Only intended for testing foreign filesystem detection of \fBmkfs.exfat\fP(8).
+.SH SEE ALSO
+.BR mmap (2)

--- a/manpages/fsck.exfat.8
+++ b/manpages/fsck.exfat.8
@@ -97,7 +97,15 @@ Repair the filesystem answering yes to all questions.
 .B \-b
 Try to repair the filesystem even if the exFAT filesystem is not found.
 
-.SH NOTE
+.SH ENVIRONMENT
+Following influential environment variables can be used to reduce memory
+footprint. See \fBexfatprogs-env\fP(7) for detail.
+.IP
+\fBEXFAT_MMAP\fR="3"
+.IP
+\fBEXFAT_SCRATCH_AMAP\fR="/var/tmp"
+
+.SH NOTES
 \fBmkfs.exfat\fR version \fI1.3.2\fR and older created exFAT volumes with no MBR
 partition entry even when it was required for use with Microsoft Windows
 systems, leading to some compatibility issues. \fB\-\-put-mbr\fR option may be

--- a/manpages/lsdosattr.1
+++ b/manpages/lsdosattr.1
@@ -65,7 +65,7 @@ on usage error
 .B 3
 when an error occurred but at least one file was successfully listed
 
-.SH NOTE
+.SH NOTES
 .P
 Linux kernel does not provide a special interface for reading the VDL(valid data
 length). If the in-kernel exFAT implementation is "VDL-aware", the VDL offset is

--- a/manpages/mkfs.exfat.8
+++ b/manpages/mkfs.exfat.8
@@ -204,4 +204,5 @@ Prints the version number and exits.
 .SH SEE ALSO
 .BR mkfs (8),
 .BR mount (8),
-.BR mkfs.fat (8)
+.BR mkfs.fat (8),
+.BR exfatprogs-env (7)

--- a/tests/test_fsck.sh
+++ b/tests/test_fsck.sh
@@ -5,7 +5,7 @@ NEED_LOOPDEV=$2
 IMAGE_FILE=exfat.img
 FSCK_PROG=${FSCK1:-"fsck.exfat"}
 FSCK_PROG_2=${FSCK2:-"fsck.exfat"}
-FSCK_OPTS="-y -s"
+FSCK_OPTS="-y -s $FSCK_OPTS_EXTRA"
 PASS_COUNT=0
 
 cleanup() {

--- a/tune/tune.c
+++ b/tune/tune.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	exfat = exfat_alloc_exfat(&bd, NULL, NULL);
+	exfat = exfat_alloc_exfat(&bd, NULL, NULL, false);
 	if (!exfat) {
 		ret = -ENOMEM;
 		goto out;


### PR DESCRIPTION
Under review until August 2026.

<img width="608" height="146" alt="sigbus-blinker" src="https://github.com/user-attachments/assets/9f9a9b26-4fe2-4e93-8232-5896b837f3e4" />

```
==========
Background
==========

The problem with allocation bitmaps is that they can get huge. It
contradicts the fact that exFAT is designed to be a simple filesystem
that is easy to implement and run on restrictive systems, more
specifically, memory-constrained systems. We can reduce the size of
allocation bitmap by increasing the cluster size and this seems to be
the path Microsoft has chosen for Windows. The default cluster size of
128 KiB is still quite large and the upper limit has been jacked up to
1 MiB in the recent release of Windows. Allocating 1 MiB just to create
a dentry and a text-based metadata file is unacceptable. An effort is
needed to keep the cluster size at bay.

Currently, exfatprogs utils maintain up to 3 copies of allocation
bitmaps for the volume operated on.

  1. disk_bitmap: the allocation bitmap as stored "on the disk"
  2. alloc_bitmap: a temporary copy of allocation bitmap for authoring
    or repairing purposes
  3. ohead_bitmap: another temporary copy of allocation bitmap for
    repairing purposes

All of which are kept on dynamically allocated memory. I saw an
opportunity of reducing RSS footprint by leveraging mmap() and removing
a copy of bitmap altogether by improving the algorithm.

=======
Feature
=======

The patches introduce following features:

  1. disk_bitmap: mmap() the region of allocation bitmap on the blockdev
    directly into the address space
  2. alloc_bitmap: create an O_TMPFILE in a disk-backed mount point,
    fallocate() the space required, and then mmap() the file
  3. ohead_bitmap: remove by improving fsck algorithms

As exFAT is not used as a rootfs, fsck can enjoy the luxury of being
able to use disk-backed mount points to offload alloc_bitmap to
a file-backed mapping. This way, all of the copies of allocation bitmaps
required to perform fsck duties can be offloaded entirely to disk-backed
storage rather than precious DRAM.

With this feature, it should be possible for SoC-based systems with
limited RAM to do mkfs.exfat, fsck.exfat, dump.exfat, etc on storage
devices as big as they come provided there's enough space in the
secondary storage to hold a copy of allocation bitmap.

Technically, having a large swap alleviated the problem by some degree.
The ability to specify the path to the temporary file gives the user
more flexibility.

e2fsck offers somewhat similar feature controlled by the "scratch_files"
stanza in e2fsck.conf. The main difference is that exfatprogs relies on
mmap() for a simpler implementation.

=====
Usage
=====

Using mmap() to implement fsck is a radical approach. Almost no other
fsprogs do this. In addition, there might be some unforeseeable
implications when mapping blockdev to manipulate the contents of the
storage device. Therefore, a decision was made to make this feature
optional.

mmap() bitmap handling can be enabled using these influential
environment variables:

  - EXFAT_SCRATCH_AMAP: path to the directory in which an unnamed
    inode temporary file(O_TMPFILE) is created. Defaults to "/tmp",
    which is usually a tmpfs mount point
  - EXFAT_MMAP: bit field to control the mmap() behaviour. The second
    LSB(0x02) enables the use of mmap() on allocation bitmaps. Defaults
    to 0x01(only do mmap() on /dev/zero in mkfs).

The usual usage is:

  EXFAT_SCRATCH_AMAP=/var/tmp EXFAT_MMAP=3 fsck.exfat -as TARGET

The environment variables may be exported in /etc/profile.d if desired.

=====
Notes
=====

Documentation work follow upon ACK.

EXFAT_SCRATCH_AMAP defaults to /tmp because /var/tmp is not universal
and may not exist. May as well change it to /var since only O_TMPFILE is
tried so users could just worry about setting EXFAT_MMAP=3.

CI run result using EXFAT_SCRATCH_AMAP=/var/tmp EXFAT_MMAP=3

  https://github.com/dxdxdt/exfatprogs/actions/runs/28792349076

Doesn't apply to exfat-next branch yet due to the pending PR:

  https://github.com/exfatprogs/exfatprogs/pull/377

Working branch:

  https://github.com/dxdxdt/exfatprogs/tree/fsck-memopt


Davo

David Timber (5):
  dump: remove use of exfat->alloc_bitmap
  libexfat: remove use of exfat->alloc_bitmap in exfat_root_clus_count()
  treewide: add mmap() based allocation bitmap handling support
  treewide: consolidate env vars
  treewide: add support for granular control of mmap()

 defrag/defrag.c       |   9 +-
 dump/dump.c           |  34 +++---
 exfat2img/exfat2img.c |  10 +-
 fsck/fsck.c           | 273 ++++++++++++++++++++++++------------------
 include/env.h         |  25 ++++
 include/exfat_fs.h    |  66 +++++++++-
 include/libexfat.h    |   8 ++
 label/label.c         |   2 +-
 lib/exfat_dir.c       |   5 +-
 lib/exfat_fs.c        | 230 +++++++++++++++++++++++++++++++----
 lib/libexfat.c        |  41 +++++--
 tune/tune.c           |   2 +-
 12 files changed, 519 insertions(+), 186 deletions(-)
 create mode 100644 include/env.h

-- 
2.55.0
```