### PR TITLE
Bug fixes and optimisations (July 2026 #2)

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -67,9 +67,15 @@ jobs:
     - name: Build
       run: |
         export "CC=${{ matrix.cc }}"
-        ./autogen.sh && ./configure
+        ./autogen.sh && ./configure --enable-tests
         make -j "$(nproc)"
         sudo make install
+    - name: Run internal tests with Valgrind
+      run: |
+        set -e
+        pushd ./lib/tests
+        TEST_PREOP="valgrind --error-exitcode=1" ./run-all.sh
+        popd
     - name: Run fsck with Valgrind
       run: |
         pushd tests
@@ -223,8 +229,15 @@ jobs:
         CFLAGS: --static
         PKG_CONFIG_PATH: /usr/${{ matrix.host }}/local/lib/pkgconfig
       run: |
-        ./configure --host=${{ matrix.host }}
+        ./configure --host=${{ matrix.host }} --enable-tests
         make -j$((`nproc`+1))
+
+    - name: Run internal tests
+      run: |
+        set -e
+        pushd ./lib/tests
+        ./run-all.sh
+        popd
 
     - name: Test foreign filesystem detection
       env:

--- a/configure.ac
+++ b/configure.ac
@@ -51,4 +51,10 @@ AM_COND_IF(
 PKG_CHECK_MODULES([BLKID], [blkid >= 2.20], [AC_DEFINE([HAVE_BLKID], [1], [Define if libblkid is from util-linux])],
 	[PKG_CHECK_MODULES([EXT2_BLKID], [blkid], [AC_DEFINE([HAVE_EXT2_BLKID], [1], [Define if libblkid is from libext2])])])
 
+AC_ARG_ENABLE([tests],
+	AS_HELP_STRING([--enable-tests], [build internal test programs])
+	[enable_tests=yes]
+)
+AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" = xyes])
+
 AC_OUTPUT

--- a/dump/dump.c
+++ b/dump/dump.c
@@ -488,6 +488,38 @@ static void exfat_show_file_dentry(struct exfat_dentry *ed,
 		struct exfat *exfat, uint32_t flags)
 {
 	uint16_t checksum = calc_dentry_set_checksum(ed, ed->file_num_ext + 1);
+	union exfat_timestamp btime = {
+		.time_part = le16_to_cpu(ed->file_create_time),
+		.date_part = le16_to_cpu(ed->file_create_date),
+	};
+	union exfat_timestamp mtime = {
+		.time_part = le16_to_cpu(ed->file_modify_time),
+		.date_part = le16_to_cpu(ed->file_modify_date),
+	};
+	union exfat_timestamp atime = {
+		.time_part = le16_to_cpu(ed->file_access_time),
+		.date_part = le16_to_cpu(ed->file_access_date),
+	};
+	char btime_str[EXFAT_TIMESTAMP_STRLEN];
+	char mtime_str[EXFAT_TIMESTAMP_STRLEN];
+	char atime_str[EXFAT_TIMESTAMP_STRLEN];
+
+	btime_str[0] = mtime_str[0] = atime_str[0] = 0;
+
+	exfat_format_timestamp(btime_str, EXFAT_TIMESTAMP_STRLEN, &btime,
+			ed->file_create_time_ms, ed->file_create_tz);
+	exfat_format_timestamp(mtime_str, EXFAT_TIMESTAMP_STRLEN, &mtime,
+			ed->file_modify_time_ms, ed->file_modify_tz);
+	exfat_format_timestamp(atime_str, EXFAT_TIMESTAMP_STRLEN, &atime,
+			0, ed->file_access_tz);
+
+	/* Flip them back to LE on BE arch. */
+	btime.time_part = cpu_to_le16(btime.time_part);
+	btime.date_part = cpu_to_le16(btime.date_part);
+	mtime.time_part = cpu_to_le16(mtime.time_part);
+	mtime.date_part = cpu_to_le16(mtime.date_part);
+	atime.time_part = cpu_to_le16(atime.time_part);
+	atime.date_part = cpu_to_le16(atime.date_part);
 
 	dump_dentry_field("SecondaryCount", "%u", ed->file_num_ext);
 	if (checksum == le16_to_cpu(ed->file_checksum))
@@ -496,9 +528,9 @@ static void exfat_show_file_dentry(struct exfat_dentry *ed,
 		dump_dentry_field("SetChecksum", "0x%04X(expected: 0x%04X)",
 				le16_to_cpu(ed->file_checksum), checksum);
 	dump_dentry_field("FileAttributes", "0x%04X", le16_to_cpu(ed->file_attr));
-	dump_dentry_field("CreateTimestamp", "0x%08X", le32_to_cpu(ed->file_create_time));
-	dump_dentry_field("LastModifiedTimestamp", "0x%08X", le32_to_cpu(ed->file_modify_time));
-	dump_dentry_field("LastAccessedTimestamp", "0x%08X", le32_to_cpu(ed->file_access_time));
+	dump_dentry_field("CreateTimestamp", "0x%08X\t%s", cpu_to_le32(btime.raw), btime_str);
+	dump_dentry_field("LastModifiedTimestamp", "0x%08X\t%s", cpu_to_le32(mtime.raw), mtime_str);
+	dump_dentry_field("LastAccessedTimestamp", "0x%08X\t%s", cpu_to_le32(atime.raw), atime_str);
 	dump_dentry_field("Create10msIncrement", "%u", ed->file_create_time_ms);
 	dump_dentry_field("LastModified10msIncrement", "%u", ed->file_modify_time_ms);
 	dump_dentry_field("CreateUtcOffset", "%u", ed->file_create_tz);

--- a/include/exfat_dir.h
+++ b/include/exfat_dir.h
@@ -60,6 +60,14 @@ struct exfat_lookup_filter {
 	} out;
 };
 
+union exfat_timestamp {
+	uint32_t raw;
+	struct {
+		uint16_t time_part;
+		uint16_t date_part;
+	};
+};
+
 int exfat_de_iter_init(struct exfat_de_iter *iter, struct exfat *exfat,
 		       struct exfat_inode *dir, struct buffer_desc *bd);
 int exfat_de_iter_get(struct exfat_de_iter *iter,
@@ -103,4 +111,11 @@ int exfat_find_free_cluster(struct exfat *exfat, int clu_count,
 		clus_t *new_clu);
 int exfat_alloc_cluster(struct exfat *exfat, struct exfat_inode *inode,
 		clus_t *new_clu);
+
+/* Buffer len: at least 30 characters including the null-terminator */
+#define EXFAT_TIMESTAMP_STRLEN (30)
+
+int exfat_format_timestamp(char *out, size_t size,
+		const union exfat_timestamp *ts, uint8_t cs, uint8_t tz);
+
 #endif

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -160,27 +160,36 @@ static inline bool exfat_ui_has_upcase_file(const struct exfat_user_input *ui)
 struct exfat;
 struct exfat_inode;
 
-#ifdef WORDS_BIGENDIAN
-typedef __u8	bitmap_t;
+#ifdef __BITS_PER_LONG
+#define BITS_PER	__BITS_PER_LONG
 #else
-typedef __u32	bitmap_t;
+/* Non-Linux polyfill(use C23) */
+#define BITS_PER	ULONG_WIDTH
 #endif
 
-#define BITS_PER	(sizeof(bitmap_t) * 8)
-#define BIT_MASK(__c)	(1 << ((__c) % BITS_PER))
-#define BIT_ENTRY(__c)	((__c) / BITS_PER)
+#if BITS_PER == 64
+typedef __u64		bitmap_t;
+#define BIT_MASK(__c)	cpu_to_le64((bitmap_t)1 << ((__c) % BITS_PER))
+#elif BITS_PER == 32
+typedef __u32		bitmap_t;
+#define BIT_MASK(__c)	cpu_to_le32((bitmap_t)1 << ((__c) % BITS_PER))
+#else
+#error "BITS_PER neither 32 or 64"
+#endif
+#define BIT_ENTRY(__c)			((__c) / BITS_PER)
+#define BITMAP_WORD_AT(bmap, bit)	((bitmap_t *)(bmap))[BIT_ENTRY(bit)]
 
 #define EXFAT_BITMAP_SIZE(__c_count)	\
 	(DIV_ROUND_UP(__c_count, BITS_PER) * sizeof(bitmap_t))
 
 #define BITMAP_GET(bmap, bit)	\
-	(((bitmap_t *)(bmap))[BIT_ENTRY(bit)] & BIT_MASK(bit))
+	(BITMAP_WORD_AT(bmap, bit) & BIT_MASK(bit))
 
 #define BITMAP_SET(bmap, bit)	\
-	(((bitmap_t *)(bmap))[BIT_ENTRY(bit)] |= BIT_MASK(bit))
+	(BITMAP_WORD_AT(bmap, bit) |= BIT_MASK(bit))
 
 #define BITMAP_CLEAR(bmap, bit)	\
-	(((bitmap_t *)(bmap))[BIT_ENTRY(bit)] &= ~BIT_MASK(bit))
+	(BITMAP_WORD_AT(bmap, bit) &= ~BIT_MASK(bit))
 
 static inline bool exfat_bitmap_get(unsigned char *bmap, clus_t c)
 {
@@ -199,7 +208,8 @@ static inline void exfat_bitmap_set(unsigned char *bmap, clus_t c)
 static inline void exfat_bitmap_clear(unsigned char *bmap, clus_t c)
 {
 	clus_t cc = c - EXFAT_FIRST_CLUSTER;
-	(((bitmap_t *)(bmap))[BIT_ENTRY(cc)] &= ~BIT_MASK(cc));
+
+	BITMAP_CLEAR(bmap, cc);
 }
 
 void exfat_bitmap_set_range(struct exfat *exfat, unsigned char *bitmap,

--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -209,10 +209,16 @@ int exfat_bitmap_find_zero(struct exfat *exfat, unsigned char *bmap,
 int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 			  clus_t start_clu, clus_t *next);
 /*
- * Count ones in the bitmap. The function won't handle unaligned bitmaps.
+ * Count ones in the bitmap
+ *
+ * Reads up to the smallest of `size` bytes or the bytes inferred from
+ * `total_clus` are read from `bitmap`.
+ *
+ * The function won't handle unaligned memory access. `bitmap` is required to be
+ * at a word boundary(unsigned long).
  */
-unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len,
-		const unsigned int clamp);
+unsigned int exfat_count_used_clusters(const void *bitmap, const size_t size,
+		const unsigned int total_clus);
 
 void show_version(void);
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -2,3 +2,12 @@ AM_CFLAGS = -Wall -include $(top_builddir)/config.h -I$(top_srcdir)/include -fno
 noinst_LIBRARIES = libexfat.a
 
 libexfat_a_SOURCES = libexfat.c exfat_fs.c exfat_dir.c utils.c
+
+if ENABLE_TESTS
+
+noinst_PROGRAMS = tests/suite0000-bitmap
+
+tests_suite0000_bitmap_SOURCES = tests/suite0000-bitmap.c
+tests_suite0000_bitmap_LDADD = libexfat.a
+
+endif

--- a/lib/exfat_dir.c
+++ b/lib/exfat_dir.c
@@ -1058,3 +1058,38 @@ out:
 	free(dset);
 	return err;
 }
+
+int exfat_format_timestamp(char *out, size_t size,
+		const union exfat_timestamp *ts, uint8_t cs, uint8_t tz)
+{
+	char tz_part[sizeof("+00:00")];
+	const unsigned int year = 1980 + (ts->date_part >> 9);
+	const unsigned int mon = (ts->date_part >> 5) & 0x000F;
+	const unsigned int day = ts->date_part & 0x001F;
+	const unsigned int hour = ts->time_part >> 11;
+	const unsigned int min = (ts->time_part >> 5) & 0x003F;
+	const unsigned int sec = (ts->time_part & 0x001F) << 1;
+	const unsigned int msec = sec * 1000 + cs * 10;
+
+	tz_part[0] = 0;
+	if (tz & 0x80) {
+		unsigned int tzoff = tz & 0x7F;
+		unsigned int tz_hour, tz_min;
+		char sign;
+
+		if (tzoff <= 0x3F) {
+			tzoff *= 15;
+			sign = '+';
+		} else {
+			tzoff = (0x80 - tzoff) * 15;
+			sign = '-';
+		}
+		tz_hour = tzoff / 60;
+		tz_min = tzoff % 60;
+
+		snprintf(tz_part, sizeof(tz_part), "%c%02u:%02u", sign, tz_hour, tz_min);
+	}
+
+	return snprintf(out, size, "%04u-%02u-%02uT%02u:%02u:%02u.%03u%s",
+			year, mon, day, hour, min, msec / 1000, msec % 1000, tz_part);
+}

--- a/lib/exfat_dir.c
+++ b/lib/exfat_dir.c
@@ -390,7 +390,7 @@ int exfat_de_iter_revert(struct exfat_de_iter *iter, int num)
 out:
 	iter->max_skip_dentries = 0;
 	iter->de_file_offset = file_offset;
-	iter->next_read_offset = (file_offset & ~(iter->read_size - 1)) + iter->read_size;
+	iter->next_read_offset = (file_offset & ~((off_t)iter->read_size - 1)) + iter->read_size;
 
 	return 0;
 }

--- a/lib/libexfat.c
+++ b/lib/libexfat.c
@@ -115,20 +115,37 @@ int exfat_bitmap_find_one(struct exfat *exfat, unsigned char *bmap,
 				     start_clu, next, 1);
 }
 
-unsigned int exfat_count_used_clusters(const void *bitmap, const size_t bitmap_len,
-		const unsigned int clamp)
+unsigned int exfat_count_used_clusters(const void *bitmap, const size_t size,
+		const unsigned int total_clus)
 {
-	const size_t lc = bitmap_len / sizeof(unsigned long);
+	const size_t content_len = DIV_ROUND_UP(total_clus, 8);
+	const size_t lb_index = content_len - 1;
+	const size_t calc_len = MIN(size, content_len);
+	const unsigned int last_bits = total_clus % CHAR_BIT;
+	const size_t lc = calc_len / sizeof(unsigned long);
 	unsigned int ret = 0;
 
 	assert((uintptr_t)bitmap % sizeof(unsigned long) == 0);
 
 	for (size_t i = 0; i < lc; i++)
-		ret += __builtin_popcountl(((unsigned long*)bitmap)[i]);
-	for (size_t i = lc * sizeof(unsigned long); i < bitmap_len; i++)
-		ret += __builtin_popcountl(((unsigned char*)bitmap)[i]);
+		ret += __builtin_popcountl(((unsigned long *)bitmap)[i]);
+	for (size_t i = lc * sizeof(unsigned long); i < calc_len; i++)
+		ret += __builtin_popcountl(((unsigned char *)bitmap)[i]);
 
-	return MIN(ret, clamp);
+	/*
+	 * Subtract the garbage ones in the last byte that might have been
+	 * counted. This is much simpler than trying to mask the last byte on
+	 * the fly.
+	 */
+	if (lb_index < calc_len && last_bits != 0) {
+		const unsigned char gmask = (1 << last_bits) - 1;
+		unsigned char lb = ((unsigned char *)bitmap)[lb_index];
+
+		lb &= ~gmask;
+		ret -= __builtin_popcountl(lb);
+	}
+
+	return ret;
 }
 
 

--- a/lib/tests/run-all.sh
+++ b/lib/tests/run-all.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+main()
+{
+	local tot=0
+	local ok=0
+	local fail=0
+
+	while read tc
+	do
+		tot=$(( tot + 1 ))
+
+		echo -n "$tc: "
+		eval $TEST_PREOP "$tc" $TEST_POSTOP
+		if [ "$?" -eq 0 ]; then
+			echo "PASS"
+			ok=$(( ok + 1 ))
+		else
+			echo "FAIL"
+			fail=$(( fail + 1 ))
+		fi
+	done
+
+	echo "PASS: $ok, FAIL: $fail (TOTAL: $tot)"
+
+	if [ "$fail" -gt 0 ]; then
+		exit 1
+	fi
+	exit 0
+}
+
+find . -mindepth 1 -maxdepth 1 -executable -name 'suite[[:digit:]]*' | sort | main

--- a/lib/tests/suite0000-bitmap.c
+++ b/lib/tests/suite0000-bitmap.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <assert.h>
+
+#include "exfat_ondisk.h"
+#include "libexfat.h"
+
+/* exfat_count_used_clusters() out of bounds checks. */
+static void test_count_used_clusters_0(void)
+{
+	static bitmap_t bm[2];
+	const static unsigned int tot_clus = sizeof(bm) / sizeof(bm[0]) * BITS_PER;
+	unsigned int ret;
+
+	memset(&bm, 0xFF, sizeof(bm));
+
+	/* This is no-op. */
+	ret = exfat_count_used_clusters(&bm, 0, tot_clus);
+	assert(ret == 0);
+
+	/* normal use cases */
+
+	ret = exfat_count_used_clusters(&bm, sizeof(bm), tot_clus);
+	assert(ret == tot_clus);
+
+	for (unsigned int i = 0; i <= tot_clus; i++) {
+		ret = exfat_count_used_clusters(&bm, sizeof(bm), i);
+		assert(ret == i);
+	}
+
+	/* alloc len < content len */
+	for (unsigned int i = tot_clus + 1; i < tot_clus + 10; i++) {
+		ret = exfat_count_used_clusters(&bm, sizeof(bm), i);
+		assert(ret == tot_clus);
+	}
+}
+
+/* Tests if exfat_count_used_clusters() doesn't count the garbage ones at the end. */
+static void test_count_used_clusters_1(void)
+{
+	static const unsigned int END = 0x1000;
+	bool seen_garbage = false;
+
+	for (unsigned int clus_cnt = 1; clus_cnt < END; clus_cnt++) {
+		const size_t bm_len = DIV_ROUND_UP(clus_cnt, 8);
+		const size_t bm_size = EXFAT_BITMAP_SIZE(clus_cnt);
+		unsigned char *m = malloc(bm_size);
+		unsigned int ret;
+
+		assert(bm_len <= bm_size);
+
+		/* All ones. */
+		memset(m, UCHAR_MAX, bm_size);
+		ret = exfat_count_used_clusters(m, bm_len, clus_cnt);
+		assert(ret == clus_cnt);
+
+		/* All valid bits zeros, all garbage ones. */
+		for (clus_t i = 0, j = EXFAT_FIRST_CLUSTER; i < clus_cnt; i++, j++)
+			exfat_bitmap_clear(m, j);
+		ret = exfat_count_used_clusters(m, bm_len, clus_cnt);
+		assert(ret == 0);
+
+		/* Make sure this test is valid(garbage should still be there). */
+		if (m[bm_len - 1] != 0)
+			seen_garbage = true;
+
+		free(m);
+	}
+
+	assert(seen_garbage);
+}
+
+int main(int argc, char *argv[])
+{
+	test_count_used_clusters_0();
+	test_count_used_clusters_1();
+
+	return 0;
+}

--- a/lib/tests/suite0000-bitmap.c
+++ b/lib/tests/suite0000-bitmap.c
@@ -72,10 +72,134 @@ static void test_count_used_clusters_1(void)
 	assert(seen_garbage);
 }
 
+/* Tests bitmap manipulation functions. */
+static void test_bitmap_func(void)
+{
+	static const clus_t ARR[] = {
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 1023,
+		1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031, 1032, 1032,
+		65543, 65544,
+		0
+	};
+
+	for (const clus_t *cc = ARR; *cc != 0; cc++) {
+		const size_t bm_len = DIV_ROUND_UP(*cc, 8);
+		const size_t bm_size = EXFAT_BITMAP_SIZE(*cc);
+		void *m = calloc(bm_size, 1);
+		unsigned int clus_cnt;
+
+		assert(bm_len > 0 && bm_len <= bm_size);
+
+		/* Fault the pages just for the sake of it. */
+		clus_cnt = exfat_count_used_clusters(m, bm_len, *cc);
+		assert(clus_cnt == 0);
+
+		/* 1x1 */
+		for (clus_t i = 0, j = EXFAT_FIRST_CLUSTER; i < *cc; i++, j++) {
+			bool b;
+
+			/* Test set(). */
+			exfat_bitmap_set(m, j);
+			b = exfat_bitmap_get(m, j);
+			clus_cnt = exfat_count_used_clusters(m, bm_len, *cc);
+			assert(b);
+			assert(clus_cnt == 1);
+
+			/* Test clear(). */
+			exfat_bitmap_clear(m, j);
+			clus_cnt = exfat_count_used_clusters(m, bm_len, *cc);
+			b = exfat_bitmap_get(m, j);
+			assert(!b);
+			assert(clus_cnt == 0);
+		}
+
+		/* SxS */
+		for (clus_t i = 0, j = EXFAT_FIRST_CLUSTER; i < *cc - 1; i++, j++) {
+			bool b1, b2;
+
+			/* Test set(). */
+			exfat_bitmap_set(m, j);
+			b1 = exfat_bitmap_get(m, j);
+			b2 = exfat_bitmap_get(m, j + 1);
+			assert(b1 && !b2);
+			clus_cnt = exfat_count_used_clusters(m, bm_len, *cc);
+			assert(clus_cnt == 1);
+
+			exfat_bitmap_set(m, j + 1);
+			b1 = exfat_bitmap_get(m, j);
+			b2 = exfat_bitmap_get(m, j + 1);
+			assert(b1 && b2);
+			clus_cnt = exfat_count_used_clusters(m, bm_len, *cc);
+			assert(clus_cnt == 2);
+
+			/* Test clear(). */
+			exfat_bitmap_clear(m, j);
+			b1 = exfat_bitmap_get(m, j);
+			b2 = exfat_bitmap_get(m, j + 1);
+			assert(!b1 && b2);
+			clus_cnt = exfat_count_used_clusters(m, bm_len, *cc);
+			assert(clus_cnt == 1);
+
+			exfat_bitmap_clear(m, j + 1);
+			b1 = exfat_bitmap_get(m, j);
+			b2 = exfat_bitmap_get(m, j + 1);
+			assert(!b1 && !b2);
+			clus_cnt = exfat_count_used_clusters(m, bm_len, *cc);
+			assert(clus_cnt == 0);
+		}
+
+		free(m);
+	}
+}
+
+/*
+ * Data-driven test of bitmap manipulation functions against endianness confusion
+ *
+ * This doesn't really mean anything on LE machines as the on-disk format is
+ * already in LE. Make sure this is run on BE machines.
+ */
+static void test_bitmap_endian(void)
+{
+	static const unsigned char EXPECTED_1[] = {
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+	};
+	static const unsigned char EXPECTED_2[] = {
+		0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00
+	};
+	static const unsigned char EXPECTED_3[] = {
+		0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00
+	};
+	unsigned char buf[sizeof(EXPECTED_1)];
+	int ret;
+
+	assert(sizeof(buf) % sizeof(bitmap_t) == 0);
+	assert(sizeof(buf) == sizeof(EXPECTED_1));
+	assert(sizeof(buf) == sizeof(EXPECTED_2));
+	assert(sizeof(buf) == sizeof(EXPECTED_3));
+
+	memset(buf, 0, sizeof(buf));
+	exfat_bitmap_set(buf, EXFAT_FIRST_CLUSTER + 0);
+	ret = memcmp(buf, EXPECTED_1, sizeof(buf));
+	assert(ret == 0);
+
+	memset(buf, 0, sizeof(buf));
+	exfat_bitmap_set(buf, EXFAT_FIRST_CLUSTER + 32);
+	ret = memcmp(buf, EXPECTED_2, sizeof(buf));
+	assert(ret == 0);
+
+	memset(buf, 0, sizeof(buf));
+	exfat_bitmap_set(buf, EXFAT_FIRST_CLUSTER + 0);
+	exfat_bitmap_set(buf, EXFAT_FIRST_CLUSTER + 32);
+	ret = memcmp(buf, EXPECTED_3, sizeof(buf));
+	assert(ret == 0);
+}
+
 int main(int argc, char *argv[])
 {
 	test_count_used_clusters_0();
 	test_count_used_clusters_1();
+	test_bitmap_func();
+	test_bitmap_endian();
 
 	return 0;
 }


### PR DESCRIPTION
- Closes: https://github.com/exfatprogs/exfatprogs/issues/381
- Bitmap ops are now a little bit(pun intended) faster on both little-endian and big-endian machines

https://github.com/dxdxdt/exfatprogs/actions/runs/29411488707

```
David Timber (5):
  libexfat: fix logic error in exfat_count_used_clusters()
  lib: add internal library tests
  libexfat: increase bitmap_t to wordsize
  libexfat: fix invalid bitwise aligning in exfat_de_iter_revert()
  dump: fix timestamp output

 .github/workflows/c-cpp.yml  |  17 +++-
 configure.ac                 |   6 ++
 dump/dump.c                  |  38 +++++++-
 include/exfat_dir.h          |  15 ++++
 include/libexfat.h           |  32 ++++---
 lib/Makefile.am              |   9 ++
 lib/exfat_dir.c              |  37 +++++++-
 lib/libexfat.c               |  22 ++++-
 lib/tests/run-all.sh         |  32 +++++++
 lib/tests/suite0000-bitmap.c | 170 +++++++++++++++++++++++++++++++++++
 10 files changed, 357 insertions(+), 21 deletions(-)
 create mode 100755 lib/tests/run-all.sh
 create mode 100644 lib/tests/suite0000-bitmap.c

-- 
2.55.0
```