### PR TITLE
libexfat: avoid overflow in bitmap size calculation

### DIFF
--- a/include/libexfat.h
+++ b/include/libexfat.h
@@ -180,7 +180,7 @@ typedef __u32		bitmap_t;
 #define BITMAP_WORD_AT(bmap, bit)	((bitmap_t *)(bmap))[BIT_ENTRY(bit)]
 
 #define EXFAT_BITMAP_SIZE(__c_count)	\
-	(DIV_ROUND_UP(__c_count, BITS_PER) * sizeof(bitmap_t))
+	(DIV_ROUND_UP((uint64_t)__c_count, BITS_PER) * sizeof(bitmap_t))
 
 #define BITMAP_GET(bmap, bit)	\
 	(BITMAP_WORD_AT(bmap, bit) & BIT_MASK(bit))

--- a/lib/tests/suite0000-bitmap.c
+++ b/lib/tests/suite0000-bitmap.c
@@ -194,8 +194,22 @@ static void test_bitmap_endian(void)
 	assert(ret == 0);
 }
 
+/* Tests bitmap size calculation near the maximum cluster count. */
+static void test_bitmap_size(void)
+{
+	const clus_t clus_cnt = EXFAT_MAX_NUM_CLUSTER - 1;
+	const size_t expected =
+		DIV_ROUND_UP((uint64_t)clus_cnt, BITS_PER) *
+		sizeof(bitmap_t);
+	const size_t actual = EXFAT_BITMAP_SIZE(clus_cnt);
+
+	assert(expected != 0);
+	assert(actual == expected);
+}
+
 int main(int argc, char *argv[])
 {
+	test_bitmap_size();
 	test_count_used_clusters_0();
 	test_count_used_clusters_1();
 	test_bitmap_func();


### PR DESCRIPTION
While stress-testing the latest version today, we found an integer overflow in the bitmap size calculation.

For cluster counts near the exFAT limit, `EXFAT_BITMAP_SIZE()` may return zero because `clus_t` is 32-bit and the addition inside `DIV_ROUND_UP()` wraps around.

As a result, `calloc()` may be called with a size of zero and still return a non-NULL pointer. Subsequent bitmap operations may then cause an out-of-bounds memory access.

For example, on a 64-bit system:

```text
clus_count = EXFAT_MAX_NUM_CLUSTER - 1 = 0xFFFFFFF4
BITS_PER   = 64

0xFFFFFFF4 + 63 -> 0x33  (32-bit wraparound)
EXFAT_BITMAP_SIZE(...) -> 0
```

The expected bitmap size is 536870912 bytes.

@dxdxdt, this seems to be related to the recent bitmap word-size change. When you have time, could you please help check whether the analysis above is correct? I may have missed something. Thanks!