### PR TITLE
libexfat: avoid overflow in file size calculation

### DIFF
--- a/lib/exfat_dir.c
+++ b/lib/exfat_dir.c
@@ -763,8 +763,8 @@ int exfat_update_file_dentry_set(struct exfat *exfat,
 		}
 	}
 
-	dset[1].dentry.stream.valid_size = cpu_to_le64(ccount * exfat->clus_size);
-	dset[1].dentry.stream.size = cpu_to_le64(ccount * exfat->clus_size);
+	dset[1].dentry.stream.valid_size = cpu_to_le64((uint64_t)ccount * exfat->clus_size);
+	dset[1].dentry.stream.size = cpu_to_le64((uint64_t)ccount * exfat->clus_size);
 	if (start_clu)
 		dset[1].dentry.stream.start_clu = cpu_to_le32(start_clu);
 


### PR DESCRIPTION
ccount and clus_size are both 32-bit values, so their multiplication
can overflow before being stored in the 64-bit stream entry fields.

Promote ccount to uint64_t before multiplication so the file size is
calculated using 64-bit arithmetic.

Testing:
- Built successfully on Linux
- Recovered a contiguous orphan cluster run larger than 100 GiB and
  verified that the recovered file size was correct
- checkpatch.pl --strict: no errors or warnings