### PR TITLE
exfatprogs: release 1.4.3 version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,27 @@
+exfatprogs 1.4.3 - released 2026-08-14
+======================================
+
+CHANGES :
+ * exfatprogs: honor the user's full locale for diagnostic messages
+   and date formatting.
+ * mkfs.exfat: report final fsync errors and suppress completion
+   messages with "-q".
+ * fsck.exfat: increase scan speed when scanning large unused
+   directory tails.
+
+BUG FIXES :
+ * exfatprogs: fix building DOS attribute utilities with non-Bash shells.
+ * dump.exfat and fsck.exfat: ignore reserved allocation-bitmap bits
+   when counting clusters.
+ * fsck.exfat: reject invalid sector sizes without crashing.
+ * mkfs.exfat: notify the kernel after creating partition tables.
+ * mkfs.exfat: generate GUIDs with correct version and variant fields.
+ * mkfs.exfat and tune.exfat: use standard GUID byte order for GUID
+   input and output.
+ * libexfat: fix directory iterator alignment for large offsets.
+ * exfatprogs: prevent allocation bitmap size overflow near the
+   maximum cluster count.
+
 exfatprogs 1.4.2 - released 2026-06-15
 ======================================
 

--- a/include/version.h
+++ b/include/version.h
@@ -5,7 +5,7 @@
 
 #ifndef _VERSION_H
 
-#define EXFAT_PROGS_VERSION "1.4.2"
-#define EXFAT_PROGS_RELEASE_DATE "2026-06-15"
+#define EXFAT_PROGS_VERSION "1.4.3"
+#define EXFAT_PROGS_RELEASE_DATE "2026-08-14"
 
 #endif /* !_VERSION_H */


### PR DESCRIPTION
CHANGES :
 * exfatprogs: honor the user's full locale for diagnostic messages and date formatting.
 * mkfs.exfat: report final fsync errors and suppress completion messages with "-q".
 * fsck.exfat: increase scan speed when scanning large unused directory tails.

BUG FIXES :
 * exfatprogs: fix building DOS attribute utilities with non-Bash shells.
 * dump.exfat and fsck.exfat: ignore reserved allocation-bitmap bits when counting clusters.
 * fsck.exfat: reject invalid sector sizes without crashing.
 * mkfs.exfat: notify the kernel after creating partition tables.
 * mkfs.exfat: generate GUIDs with correct version and variant fields.
 * mkfs.exfat and tune.exfat: use standard GUID byte order for GUID input and output.
 * libexfat: fix directory iterator alignment for large offsets.
 * exfatprogs: prevent allocation bitmap size overflow near the maximum cluster count.